### PR TITLE
[config] Add Orderer endpoint

### DIFF
--- a/api/types/orderer_endpoint.go
+++ b/api/types/orderer_endpoint.go
@@ -1,0 +1,167 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type (
+	// OrdererEndpoint defines an orderer party's endpoint.
+	OrdererEndpoint struct {
+		Host string `mapstructure:"host" json:"host,omitempty" yaml:"host,omitempty"`
+		Port int    `mapstructure:"port" json:"port,omitempty" yaml:"port,omitempty"`
+		// ID is the party ID.
+		ID    uint32 `mapstructure:"id" json:"id,omitempty" yaml:"id,omitempty"`
+		MspID string `mapstructure:"msp-id" json:"msp-id,omitempty" yaml:"msp-id,omitempty"`
+		// API should be broadcast and/or deliver. Empty value means all API is supported.
+		API []string `mapstructure:"api" json:"api,omitempty" yaml:"api,omitempty"`
+	}
+)
+
+const (
+	// Broadcast support by endpoint.
+	Broadcast = "broadcast"
+	// Deliver support by endpoint.
+	Deliver = "deliver"
+	// NoID indicates that a party ID is not specified (default).
+	// This allows backward compatibility with orderers that doesn't support this syntax.
+	NoID = uint32(0x100000)
+)
+
+// ErrInvalidEndpoint orderer endpoints error.
+var ErrInvalidEndpoint = errors.New("invalid endpoint")
+
+// Address returns a string representation of the endpoint's address.
+func (e *OrdererEndpoint) Address() string {
+	return net.JoinHostPort(e.Host, strconv.Itoa(e.Port))
+}
+
+// String returns a deterministic representation of the endpoint.
+func (e *OrdererEndpoint) String() string {
+	var output strings.Builder
+	isFirst := true
+	if e.ID < NoID {
+		output.WriteString("id=")
+		output.WriteString(strconv.FormatUint(uint64(e.ID), 10))
+		isFirst = false
+	}
+	if len(e.MspID) > 0 {
+		if !isFirst {
+			output.WriteRune(',')
+		}
+		output.WriteString("msp-id=")
+		output.WriteString(e.MspID)
+		isFirst = false
+	}
+	for _, api := range e.API {
+		if !isFirst {
+			output.WriteRune(',')
+		}
+		output.WriteString(api)
+		isFirst = false
+	}
+	if len(e.Host) > 0 || e.Port > 0 {
+		if !isFirst {
+			output.WriteRune(',')
+		}
+		output.WriteString(e.Address())
+	}
+	return output.String()
+}
+
+// SupportsAPI returns true if this endpoint supports API.
+// It also returns true if no APIs are specified, as we cannot know.
+func (e *OrdererEndpoint) SupportsAPI(api string) bool {
+	return len(e.API) == 0 || slices.Contains(e.API, api)
+}
+
+// ParseOrdererEndpoint parses a string according to the following schema order (the first that succeeds).
+// Schema 1: YAML.
+// Schema 2: JSON.
+// Schema 3: [id=ID,][msp-id=MspID,][broadcast,][deliver,][host=Host,][port=Port,][Host:Port].
+func ParseOrdererEndpoint(valueRaw string) (*OrdererEndpoint, error) {
+	ret := &OrdererEndpoint{ID: NoID}
+	if len(valueRaw) == 0 {
+		return ret, nil
+	}
+	if err := yaml.Unmarshal([]byte(valueRaw), ret); err == nil {
+		return ret, nil
+	}
+	if err := json.Unmarshal([]byte(valueRaw), ret); err == nil {
+		return ret, nil
+	}
+	err := unmarshalOrdererEndpoint(valueRaw, ret)
+	return ret, err
+}
+
+func unmarshalOrdererEndpoint(valueRaw string, out *OrdererEndpoint) error {
+	metaParts := strings.Split(valueRaw, ",")
+	for _, item := range metaParts {
+		item = strings.TrimSpace(item)
+		equalIdx := strings.Index(item, "=")
+		colonIdx := strings.Index(item, ":")
+		var err error
+		switch {
+		case item == Broadcast || item == Deliver:
+			out.API = append(out.API, item)
+		case equalIdx >= 0:
+			key, value := strings.TrimSpace(item[:equalIdx]), strings.TrimSpace(item[equalIdx+1:])
+			switch key {
+			case "msp-id":
+				out.MspID = value
+			case "host":
+				out.Host = value
+			case "id":
+				err = out.setID(value)
+			case "port":
+				err = out.setPort(value)
+			default:
+				return fmt.Errorf("invalid key '%s' for item '%s': %w", key, item, ErrInvalidEndpoint)
+			}
+		case colonIdx >= 0:
+			var port string
+			out.Host, port, err = net.SplitHostPort(strings.TrimSpace(item))
+			if err != nil {
+				return fmt.Errorf("invalid host/port '%s': %w", item, err)
+			}
+			err = out.setPort(strings.TrimSpace(port))
+		default:
+			return fmt.Errorf("invalid item '%s': %w", item, ErrInvalidEndpoint)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *OrdererEndpoint) setPort(portStr string) error {
+	port, err := strconv.ParseInt(portStr, 10, 32)
+	if err != nil {
+		return fmt.Errorf("failed to parse port: %w", err)
+	}
+	e.Port = int(port)
+	return nil
+}
+
+func (e *OrdererEndpoint) setID(idStr string) error {
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid id value: %w", err)
+	}
+	e.ID = uint32(id)
+	return nil
+}

--- a/api/types/orderer_endpoint_test.go
+++ b/api/types/orderer_endpoint_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestReadWrite(t *testing.T) {
+	t.Parallel()
+	valSchema := "id=5,msp-id=org,broadcast,deliver,localhost:5050"
+	valJSON := `{"id":5,"msp-id":"org","api":["broadcast","deliver"],"host":"localhost","port":5050}`
+	valYAML := `
+id: 5
+msp-id: org
+api:
+    - broadcast
+    - deliver
+host: localhost
+port: 5050
+`
+	expected := &OrdererEndpoint{
+		ID:    5,
+		MspID: "org",
+		API:   []string{"broadcast", "deliver"},
+		Host:  "localhost",
+		Port:  5050,
+	}
+	require.Equal(t, "localhost:5050", expected.Address())
+	require.Equal(t, valSchema, expected.String())
+
+	valJSONRaw, err := json.Marshal(expected)
+	require.NoError(t, err)
+	require.JSONEq(t, valJSON, string(valJSONRaw))
+
+	valYamlRaw, err := yaml.Marshal(expected)
+	require.NoError(t, err)
+	require.YAMLEq(t, valYAML, string(valYamlRaw))
+
+	e, err := ParseOrdererEndpoint(valSchema)
+	require.NoError(t, err)
+	require.Equal(t, expected, e)
+
+	e, err = ParseOrdererEndpoint(valJSON)
+	require.NoError(t, err)
+	require.Equal(t, expected, e)
+
+	e, err = ParseOrdererEndpoint(valYAML)
+	require.NoError(t, err)
+	require.Equal(t, expected, e)
+
+	valJSONNoID := `{"msp-id":"org","api":["broadcast","deliver"],"host":"localhost","port":5050}`
+	e, err = ParseOrdererEndpoint(valJSONNoID)
+	require.NoError(t, err)
+	require.Equal(t, &OrdererEndpoint{
+		ID:    NoID,
+		MspID: "org",
+		API:   []string{"broadcast", "deliver"},
+		Host:  "localhost",
+		Port:  5050,
+	}, e)
+}

--- a/cmd/common/config.go
+++ b/cmd/common/config.go
@@ -10,7 +10,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/hyperledger/fabric-x-common/cmd/common/comm"
 	"github.com/hyperledger/fabric-x-common/cmd/common/signer"

--- a/cmd/cryptogen/main.go
+++ b/cmd/cryptogen/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/internaltools/cryptogen/msp"
 
 	"github.com/alecthomas/kingpin/v2"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/cmd/cryptogen/main_test.go
+++ b/cmd/cryptogen/main_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDefaultConfigParsing(t *testing.T) {

--- a/common/channelconfig/realconfig_test.go
+++ b/common/channelconfig/realconfig_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/fabric-x-common/api/types"
 	"github.com/hyperledger/fabric-x-common/common/channelconfig"
 	"github.com/hyperledger/fabric-x-common/core/config/configtest"
 	"github.com/hyperledger/fabric-x-common/internaltools/configtxgen/encoder"
@@ -57,7 +58,7 @@ func TestOrgSpecificOrdererEndpoints(t *testing.T) {
 		require.Nil(t, cg)
 		require.EqualError(t, err, "could not create orderer group: failed to create orderer org: orderer endpoints for organization SampleOrg are missing and must be configured when capability V3_0 is enabled")
 
-		conf.Orderer.Organizations[0].OrdererEndpoints = []string{"127.0.0.1:7050"}
+		conf.Orderer.Organizations[0].OrdererEndpoints = []*types.OrdererEndpoint{{Host: "127.0.0.1", Port: 7050}}
 		cg, err = encoder.NewChannelGroup(conf)
 		require.NoError(t, err)
 

--- a/common/configtx/test/helper.go
+++ b/common/configtx/test/helper.go
@@ -67,8 +67,12 @@ func MakeGenesisBlockFromMSPs(channelID string, appMSPConf, ordererMSPConf *mspp
 		ModPolicy: channelconfig.AdminsPolicyKey,
 	}
 
+	endpoints := profile.Orderer.Organizations[0].OrdererEndpoints
 	ordererOrgProtos := &cb.OrdererAddresses{
-		Addresses: profile.Orderer.Organizations[0].OrdererEndpoints,
+		Addresses: make([]string, len(endpoints)),
+	}
+	for i, e := range endpoints {
+		ordererOrgProtos.Addresses[i] = e.String()
 	}
 	ordererOrg.Values[channelconfig.EndpointsKey] = &cb.ConfigValue{
 		Value:     protoutil.MarshalOrPanic(ordererOrgProtos),

--- a/common/viperutil/config_util.go
+++ b/common/viperutil/config_util.go
@@ -21,8 +21,9 @@ import (
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
+	"github.com/hyperledger/fabric-x-common/api/types"
 	"github.com/hyperledger/fabric-x-common/common/util"
 )
 
@@ -212,57 +213,59 @@ func toMapStringInterface(m map[interface{}]interface{}) map[string]interface{} 
 	return result
 }
 
-// customDecodeHook parses strings of the format "[thing1, thing2, thing3]"
+// StringSliceViaEnvDecodeHook parses strings of the format "[thing1, thing2, thing3]"
 // into string slices. Note that whitespace around slice elements is removed.
-func customDecodeHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
-	if f.Kind() != reflect.String {
+func StringSliceViaEnvDecodeHook(f, t reflect.Type, data any) (any, error) {
+	raw, ok := GetStringData(f, data)
+	raw = strings.TrimSpace(raw)
+	sz := len(raw)
+	if !ok || sz < 2 || !reflect.TypeFor[[]string]().AssignableTo(t) {
 		return data, nil
 	}
 
-	raw := data.(string)
-	l := len(raw)
-	if l > 1 && raw[0] == '[' && raw[l-1] == ']' {
-		slice := strings.Split(raw[1:l-1], ",")
-		for i, v := range slice {
-			slice[i] = strings.TrimSpace(v)
-		}
-		return slice, nil
+	if raw[0] != '[' || raw[sz-1] != ']' {
+		return data, nil
 	}
-
-	return data, nil
+	slice := strings.Split(raw[1:sz-1], ",")
+	for i, v := range slice {
+		slice[i] = strings.TrimSpace(v)
+	}
+	return slice, nil
 }
 
-func byteSizeDecodeHook(f reflect.Kind, t reflect.Kind, data interface{}) (interface{}, error) {
-	if f != reflect.String || t != reflect.Uint32 {
+var byteSizeRegexp = regexp.MustCompile(`(?i)^(\d+)\s*([kmg])b?$`)
+
+// ByteSizeDecodeHook is a decoder that can parse byte size encodings.
+func ByteSizeDecodeHook(f, t reflect.Type, data any) (any, error) {
+	raw, ok := GetStringData(f, data)
+	targetKind := t.Kind()
+	if !ok || raw == "" || (targetKind != reflect.Uint64 && targetKind != reflect.Uint32) {
 		return data, nil
 	}
-	raw := data.(string)
-	if raw == "" {
+	match := byteSizeRegexp.FindStringSubmatch(raw)
+	if match == nil {
 		return data, nil
 	}
-	re := regexp.MustCompile(`^(?P<size>[0-9]+)\s*(?i)(?P<unit>(k|m|g))b?$`)
-	if re.MatchString(raw) {
-		size, err := strconv.ParseUint(re.ReplaceAllString(raw, "${size}"), 0, 64)
-		if err != nil {
-			return data, nil
-		}
-		unit := re.ReplaceAllString(raw, "${unit}")
-		switch strings.ToLower(unit) {
-		case "g":
-			size = size << 10
-			fallthrough
-		case "m":
-			size = size << 10
-			fallthrough
-		case "k":
-			size = size << 10
-		}
-		if size > math.MaxUint32 {
-			return size, fmt.Errorf("value '%s' overflows uint32", raw)
-		}
+	size, err := strconv.ParseUint(match[1], 10, 64)
+	if err != nil {
+		return data, err
+	}
+	switch strings.ToLower(match[2]) {
+	case "g":
+		size <<= 30
+	case "m":
+		size <<= 20
+	case "k":
+		size <<= 10
+	}
+
+	if targetKind == reflect.Uint64 {
 		return size, nil
 	}
-	return data, nil
+	if size > math.MaxUint32 {
+		err = fmt.Errorf("value '%s' overflows uint32", raw)
+	}
+	return uint32(size), err
 }
 
 func stringFromFileDecodeHook(f reflect.Kind, t reflect.Kind, data interface{}) (interface{}, error) {
@@ -372,6 +375,25 @@ func bccspHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, e
 	return config, nil
 }
 
+// OrdererEndpointDecoder is a decoder that can parse orderer endpoint.
+func OrdererEndpointDecoder(dataType, targetType reflect.Type, rawData any) (result any, err error) {
+	stringData, ok := GetStringData(dataType, rawData)
+	if !ok || !reflect.TypeFor[types.OrdererEndpoint]().AssignableTo(targetType) {
+		return rawData, nil
+	}
+	endpoint, err := types.ParseOrdererEndpoint(stringData)
+	return endpoint, errors.Wrap(err, "failed to parse orderer endpoint")
+}
+
+// GetStringData tries to convert the raw type to string.
+func GetStringData(dataType reflect.Type, rawData any) (stringData string, isStringData bool) {
+	if dataType.Kind() != reflect.String {
+		return stringData, false
+	}
+	stringData, isStringData = rawData.(string)
+	return stringData, isStringData
+}
+
 // EnhancedExactUnmarshal is intended to unmarshal a config file into a structure
 // producing error when extraneous variables are introduced and supporting
 // the time.Duration type
@@ -397,10 +419,11 @@ func (c *ConfigParser) EnhancedExactUnmarshal(output interface{}) error {
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			bccspHook,
 			mapstructure.StringToTimeDurationHookFunc(),
-			customDecodeHook,
-			byteSizeDecodeHook,
+			StringSliceViaEnvDecodeHook,
+			ByteSizeDecodeHook,
 			stringFromFileDecodeHook,
 			pemBlocksFromFileDecodeHook,
+			OrdererEndpointDecoder,
 		),
 	}
 
@@ -409,20 +432,4 @@ func (c *ConfigParser) EnhancedExactUnmarshal(output interface{}) error {
 		return err
 	}
 	return decoder.Decode(leafKeys)
-}
-
-// YamlStringToStructHook is a hook for viper(viper.Unmarshal(*,*, here)), it is able to parse a string of minified yaml into a slice of structs
-func YamlStringToStructHook(m interface{}) func(rf reflect.Kind, rt reflect.Kind, data interface{}) (interface{}, error) {
-	return func(rf reflect.Kind, rt reflect.Kind, data interface{}) (interface{}, error) {
-		if rf != reflect.String || rt != reflect.Slice {
-			return data, nil
-		}
-
-		raw := data.(string)
-		if raw == "" {
-			return m, nil
-		}
-
-		return m, yaml.UnmarshalStrict([]byte(raw), &m)
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.75.0
 	google.golang.org/protobuf v1.36.10
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -79,5 +79,4 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internaltools/configtxgen/encoder/encoder.go
+++ b/internaltools/configtxgen/encoder/encoder.go
@@ -349,7 +349,11 @@ func NewOrdererOrgGroup(conf *genesisconfig.Organization, channelCapabilities ma
 	addValue(ordererOrgGroup, channelconfig.MSPValue(mspConfig), channelconfig.AdminsPolicyKey)
 
 	if len(conf.OrdererEndpoints) > 0 {
-		addValue(ordererOrgGroup, channelconfig.EndpointsValue(conf.OrdererEndpoints), channelconfig.AdminsPolicyKey)
+		endpoints := make([]string, len(conf.OrdererEndpoints))
+		for i, e := range conf.OrdererEndpoints {
+			endpoints[i] = e.String()
+		}
+		addValue(ordererOrgGroup, channelconfig.EndpointsValue(endpoints), channelconfig.AdminsPolicyKey)
 	} else if channelCapabilities["V3_0"] {
 		return nil, errors.Errorf("orderer endpoints for organization %s are missing and must be configured when capability V3_0 is enabled", conf.Name)
 	}

--- a/internaltools/configtxgen/encoder/encoder_test.go
+++ b/internaltools/configtxgen/encoder/encoder_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/hyperledger/fabric-x-common/api/types"
 	. "github.com/hyperledger/fabric-x-common/internaltools/test"
 
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -353,12 +354,15 @@ var _ = Describe("Encoder", func() {
 				OrdererType: "solo",
 				Organizations: []*genesisconfig.Organization{
 					{
-						MSPDir:           "../../../sampleconfig/msp",
-						ID:               "SampleMSP",
-						MSPType:          "bccsp",
-						Name:             "SampleOrg",
-						Policies:         CreateStandardPolicies(),
-						OrdererEndpoints: []string{"foo:7050", "bar:8050"},
+						MSPDir:   "../../../sampleconfig/msp",
+						ID:       "SampleMSP",
+						MSPType:  "bccsp",
+						Name:     "SampleOrg",
+						Policies: CreateStandardPolicies(),
+						OrdererEndpoints: []*types.OrdererEndpoint{
+							{Host: "foo", Port: 7050},
+							{Host: "bar", Port: 8050},
+						},
 					},
 				},
 				Policies: CreateStandardOrdererPolicies(),
@@ -670,9 +674,9 @@ var _ = Describe("Encoder", func() {
 				MSPType:  "bccsp",
 				Name:     "SampleOrg",
 				Policies: CreateStandardPolicies(),
-				OrdererEndpoints: []string{
-					"foo:7050",
-					"bar:8050",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					{Host: "foo", Port: 7050},
+					{Host: "bar", Port: 8050},
 				},
 			}
 		})
@@ -715,7 +719,7 @@ var _ = Describe("Encoder", func() {
 
 		Context("when there are no ordering endpoints", func() {
 			BeforeEach(func() {
-				conf.OrdererEndpoints = []string{}
+				conf.OrdererEndpoints = []*types.OrdererEndpoint{}
 			})
 
 			It("does not include the endpoints in the config group with v2_0", func() {

--- a/internaltools/configtxgen/genesisconfig/config.go
+++ b/internaltools/configtxgen/genesisconfig/config.go
@@ -13,10 +13,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger-labs/SmartBFT/pkg/types"
+	smartbfttypes "github.com/hyperledger-labs/SmartBFT/pkg/types"
 	"github.com/hyperledger/fabric-protos-go-apiv2/orderer/etcdraft"
 	"github.com/hyperledger/fabric-protos-go-apiv2/orderer/smartbft"
 
+	"github.com/hyperledger/fabric-x-common/api/types"
 	"github.com/hyperledger/fabric-x-common/common/util"
 	"github.com/hyperledger/fabric-x-common/common/viperutil"
 	cf "github.com/hyperledger/fabric-x-common/core/config"
@@ -139,8 +140,8 @@ type Organization struct {
 	// Note: Viper deserialization does not seem to care for
 	// embedding of types, so we use one organization struct
 	// for both orderers and applications.
-	AnchorPeers      []*AnchorPeer `yaml:"AnchorPeers"`
-	OrdererEndpoints []string      `yaml:"OrdererEndpoints"`
+	AnchorPeers      []*AnchorPeer            `yaml:"AnchorPeers"`
+	OrdererEndpoints []*types.OrdererEndpoint `yaml:"OrdererEndpoints"`
 
 	// AdminPrincipal is deprecated and may be removed in a future release
 	// it was used for modifying the default policy generation, but policies
@@ -214,21 +215,21 @@ var genesisDefaults = TopLevel{
 			},
 		},
 		SmartBFT: &smartbft.Options{
-			RequestBatchMaxCount:      types.DefaultConfig.RequestBatchMaxCount,
-			RequestBatchMaxBytes:      types.DefaultConfig.RequestBatchMaxBytes,
-			RequestBatchMaxInterval:   types.DefaultConfig.RequestBatchMaxInterval.String(),
-			IncomingMessageBufferSize: types.DefaultConfig.IncomingMessageBufferSize,
-			RequestPoolSize:           types.DefaultConfig.RequestPoolSize,
-			RequestForwardTimeout:     types.DefaultConfig.RequestForwardTimeout.String(),
-			RequestComplainTimeout:    types.DefaultConfig.RequestComplainTimeout.String(),
-			RequestAutoRemoveTimeout:  types.DefaultConfig.RequestAutoRemoveTimeout.String(),
-			ViewChangeResendInterval:  types.DefaultConfig.ViewChangeResendInterval.String(),
-			ViewChangeTimeout:         types.DefaultConfig.ViewChangeTimeout.String(),
-			LeaderHeartbeatTimeout:    types.DefaultConfig.LeaderHeartbeatTimeout.String(),
-			LeaderHeartbeatCount:      types.DefaultConfig.LeaderHeartbeatCount,
-			CollectTimeout:            types.DefaultConfig.CollectTimeout.String(),
-			SyncOnStart:               types.DefaultConfig.SyncOnStart,
-			SpeedUpViewChange:         types.DefaultConfig.SpeedUpViewChange,
+			RequestBatchMaxCount:      smartbfttypes.DefaultConfig.RequestBatchMaxCount,
+			RequestBatchMaxBytes:      smartbfttypes.DefaultConfig.RequestBatchMaxBytes,
+			RequestBatchMaxInterval:   smartbfttypes.DefaultConfig.RequestBatchMaxInterval.String(),
+			IncomingMessageBufferSize: smartbfttypes.DefaultConfig.IncomingMessageBufferSize,
+			RequestPoolSize:           smartbfttypes.DefaultConfig.RequestPoolSize,
+			RequestForwardTimeout:     smartbfttypes.DefaultConfig.RequestForwardTimeout.String(),
+			RequestComplainTimeout:    smartbfttypes.DefaultConfig.RequestComplainTimeout.String(),
+			RequestAutoRemoveTimeout:  smartbfttypes.DefaultConfig.RequestAutoRemoveTimeout.String(),
+			ViewChangeResendInterval:  smartbfttypes.DefaultConfig.ViewChangeResendInterval.String(),
+			ViewChangeTimeout:         smartbfttypes.DefaultConfig.ViewChangeTimeout.String(),
+			LeaderHeartbeatTimeout:    smartbfttypes.DefaultConfig.LeaderHeartbeatTimeout.String(),
+			LeaderHeartbeatCount:      smartbfttypes.DefaultConfig.LeaderHeartbeatCount,
+			CollectTimeout:            smartbfttypes.DefaultConfig.CollectTimeout.String(),
+			SyncOnStart:               smartbfttypes.DefaultConfig.SyncOnStart,
+			SpeedUpViewChange:         smartbfttypes.DefaultConfig.SpeedUpViewChange,
 		},
 		Arma: &ConsensusMetadata{},
 	},

--- a/internaltools/configtxgen/tools_test.go
+++ b/internaltools/configtxgen/tools_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/fabric-x-common/api/types"
 	"github.com/hyperledger/fabric-x-common/common/channelconfig"
 	"github.com/hyperledger/fabric-x-common/core/config/configtest"
 	"github.com/hyperledger/fabric-x-common/internaltools/configtxgen/genesisconfig"
@@ -16,10 +17,12 @@ import (
 )
 
 func TestInspectMissing(t *testing.T) {
+	t.Parallel()
 	require.EqualError(t, DoInspectBlock("NonSenseBlockFileThatDoesn'tActuallyExist"), "could not read block NonSenseBlockFileThatDoesn'tActuallyExist")
 }
 
 func TestInspectBlock(t *testing.T) {
+	t.Parallel()
 	blockDest := filepath.Join(t.TempDir(), "block")
 
 	config := genesisconfig.Load(genesisconfig.SampleAppChannelInsecureSoloProfile, configtest.GetDevConfigDir())
@@ -29,6 +32,7 @@ func TestInspectBlock(t *testing.T) {
 }
 
 func TestInspectBlockErr(t *testing.T) {
+	t.Parallel()
 	config := genesisconfig.Load(genesisconfig.SampleAppChannelInsecureSoloProfile, configtest.GetDevConfigDir())
 
 	require.EqualError(t, DoOutputBlock(config, "foo", ""), "error writing genesis block: open : no such file or directory")
@@ -36,6 +40,7 @@ func TestInspectBlockErr(t *testing.T) {
 }
 
 func TestMissingOrdererSection(t *testing.T) {
+	t.Parallel()
 	blockDest := filepath.Join(t.TempDir(), "block")
 
 	config := genesisconfig.Load(genesisconfig.SampleAppChannelInsecureSoloProfile, configtest.GetDevConfigDir())
@@ -45,6 +50,7 @@ func TestMissingOrdererSection(t *testing.T) {
 }
 
 func TestApplicationChannelGenesisBlock(t *testing.T) {
+	t.Parallel()
 	blockDest := filepath.Join(t.TempDir(), "block")
 
 	config := genesisconfig.Load(genesisconfig.SampleAppChannelInsecureSoloProfile, configtest.GetDevConfigDir())
@@ -53,6 +59,7 @@ func TestApplicationChannelGenesisBlock(t *testing.T) {
 }
 
 func TestApplicationChannelMissingApplicationSection(t *testing.T) {
+	t.Parallel()
 	blockDest := filepath.Join(t.TempDir(), "block")
 
 	config := genesisconfig.Load(genesisconfig.SampleAppChannelInsecureSoloProfile, configtest.GetDevConfigDir())
@@ -62,6 +69,7 @@ func TestApplicationChannelMissingApplicationSection(t *testing.T) {
 }
 
 func TestMissingConsortiumValue(t *testing.T) {
+	t.Parallel()
 	configTxDest := filepath.Join(t.TempDir(), "configtx")
 
 	config := genesisconfig.Load(genesisconfig.SampleSingleMSPChannelProfile, configtest.GetDevConfigDir())
@@ -71,6 +79,7 @@ func TestMissingConsortiumValue(t *testing.T) {
 }
 
 func TestUnsuccessfulChannelTxFileCreation(t *testing.T) {
+	t.Parallel()
 	configTxDest := filepath.Join(t.TempDir(), "configtx")
 
 	config := genesisconfig.Load(genesisconfig.SampleSingleMSPChannelProfile, configtest.GetDevConfigDir())
@@ -79,6 +88,7 @@ func TestUnsuccessfulChannelTxFileCreation(t *testing.T) {
 }
 
 func TestMissingApplicationValue(t *testing.T) {
+	t.Parallel()
 	configTxDest := filepath.Join(t.TempDir(), "configtx")
 
 	config := genesisconfig.Load(genesisconfig.SampleSingleMSPChannelProfile, configtest.GetDevConfigDir())
@@ -88,10 +98,12 @@ func TestMissingApplicationValue(t *testing.T) {
 }
 
 func TestInspectMissingConfigTx(t *testing.T) {
+	t.Parallel()
 	require.EqualError(t, DoInspectChannelCreateTx("ChannelCreateTxFileWhichDoesn'tReallyExist"), "could not read channel create tx: open ChannelCreateTxFileWhichDoesn'tReallyExist: no such file or directory")
 }
 
 func TestInspectConfigTx(t *testing.T) {
+	t.Parallel()
 	configTxDest := filepath.Join(t.TempDir(), "configtx")
 
 	config := genesisconfig.Load(genesisconfig.SampleSingleMSPChannelProfile, configtest.GetDevConfigDir())
@@ -101,6 +113,7 @@ func TestInspectConfigTx(t *testing.T) {
 }
 
 func TestPrintOrg(t *testing.T) {
+	t.Parallel()
 	require.NoError(t, factory.InitFactories(nil))
 	config := genesisconfig.LoadTopLevel(configtest.GetDevConfigDir())
 
@@ -133,6 +146,7 @@ func addTlsCertToConsenters(config *genesisconfig.Profile) {
 }
 
 func TestBftOrdererTypeWithoutV3CapabilitiesShouldRaiseAnError(t *testing.T) {
+	t.Parallel()
 	// ### Arrange
 	blockDest := filepath.Join(t.TempDir(), "block")
 	config := createBftOrdererConfig()
@@ -149,6 +163,7 @@ func TestBftOrdererTypeWithoutV3CapabilitiesShouldRaiseAnError(t *testing.T) {
 }
 
 func TestBftOrdererTypeWithV3CapabilitiesShouldNotRaiseAnError(t *testing.T) {
+	t.Parallel()
 	// ### Arrange
 	blockDest := filepath.Join(t.TempDir(), "block")
 	config := createBftOrdererConfig()
@@ -159,27 +174,70 @@ func TestBftOrdererTypeWithV3CapabilitiesShouldNotRaiseAnError(t *testing.T) {
 }
 
 func TestFabricXGenesisBlock(t *testing.T) {
-	blockDest := filepath.Join(t.TempDir(), "block")
+	t.Parallel()
 
 	keyPath := filepath.Join(configtest.GetDevConfigDir(), "msp", "signcerts", "peer.pem")
+	allAPI := []string{types.Broadcast, types.Deliver}
 
-	for _, p := range []string{genesisconfig.SampleFabricX, genesisconfig.TwoOrgsSampleFabricX} {
-		config := genesisconfig.Load(p, configtest.GetDevConfigDir())
-		addTlsCertToConsenters(config)
-		config.Application.MetaNamespaceVerificationKeyPath = keyPath
-		armaPath := filepath.Join(configtest.GetDevConfigDir(), "arma_shared_config.pbbin")
-		config.Orderer.Arma.Path = armaPath
-		require.NoError(t, DoOutputBlock(config, "foo", blockDest))
+	for _, tc := range []struct {
+		sample            string
+		expectedEndpoints []*types.OrdererEndpoint
+	}{
+		{
+			sample: genesisconfig.SampleFabricX,
+			expectedEndpoints: []*types.OrdererEndpoint{
+				{MspID: "SampleOrg", ID: 0, API: allAPI[:1], Host: "orderer-1", Port: 7050},
+				{MspID: "SampleOrg", ID: 0, API: allAPI[1:], Host: "orderer-1", Port: 7060},
+				{MspID: "SampleOrg", ID: 1, API: allAPI, Host: "orderer-2", Port: 7050},
+				{MspID: "SampleOrg", ID: 2, API: nil, Host: "orderer-3", Port: 7050},
+			},
+		}, {
+			sample: genesisconfig.TwoOrgsSampleFabricX,
+			expectedEndpoints: []*types.OrdererEndpoint{
+				{MspID: "Org1", ID: 0, API: allAPI[:1], Host: "localhost", Port: 7050},
+				{MspID: "Org1", ID: 0, API: allAPI[1:], Host: "localhost", Port: 7060},
+				{MspID: "Org2", ID: 1, API: allAPI[:1], Host: "localhost", Port: 7051},
+				{MspID: "Org2", ID: 1, API: allAPI[1:], Host: "localhost", Port: 7061},
+			},
+		},
+	} {
+		t.Run(tc.sample, func(t *testing.T) {
+			t.Parallel()
+			blockDest := filepath.Join(t.TempDir(), "block")
+			config := genesisconfig.Load(tc.sample, configtest.GetDevConfigDir())
+			addTlsCertToConsenters(config)
+			config.Application.MetaNamespaceVerificationKeyPath = keyPath
+			armaPath := filepath.Join(configtest.GetDevConfigDir(), "arma_shared_config.pbbin")
+			config.Orderer.Arma.Path = armaPath
+			require.NoError(t, DoOutputBlock(config, "foo", blockDest))
 
-		configBlock, err := ReadBlock(blockDest)
-		require.NoError(t, err)
-		require.NotNil(t, configBlock)
+			configBlock, err := ReadBlock(blockDest)
+			require.NoError(t, err)
+			require.NotNil(t, configBlock)
 
-		envelope, err := protoutil.ExtractEnvelope(configBlock, 0)
-		require.NoError(t, err)
-		require.NotNil(t, envelope)
-		bundle, err := channelconfig.NewBundleFromEnvelope(envelope, factory.GetDefault())
-		require.NoError(t, err)
-		require.NotNil(t, bundle)
+			envelope, err := protoutil.ExtractEnvelope(configBlock, 0)
+			require.NoError(t, err)
+			require.NotNil(t, envelope)
+			bundle, err := channelconfig.NewBundleFromEnvelope(envelope, factory.GetDefault())
+			require.NoError(t, err)
+			require.NotNil(t, bundle)
+
+			oc, ok := bundle.OrdererConfig()
+			require.True(t, ok)
+			require.NotNil(t, oc)
+
+			var endpoints []*types.OrdererEndpoint
+			for orgID, org := range oc.Organizations() {
+				endpointsStr := org.Endpoints()
+				for _, eStr := range endpointsStr {
+					t.Log(eStr)
+					e, parseErr := types.ParseOrdererEndpoint(eStr)
+					require.NoError(t, parseErr)
+					e.MspID = orgID
+					endpoints = append(endpoints, e)
+				}
+			}
+			require.ElementsMatch(t, tc.expectedEndpoints, endpoints)
+		})
 	}
 }

--- a/internaltools/cryptogen/msp/msp.go
+++ b/internaltools/cryptogen/msp/msp.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/hyperledger/fabric-x-common/internaltools/cryptogen/ca"
 	"github.com/hyperledger/fabric-x-common/internaltools/cryptogen/csp"

--- a/internaltools/cryptogen/msp/msp_test.go
+++ b/internaltools/cryptogen/msp/msp_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/hyperledger/fabric-x-common/internaltools/cryptogen/ca"
 	"github.com/hyperledger/fabric-x-common/internaltools/cryptogen/msp"

--- a/msp/configbuilder.go
+++ b/msp/configbuilder.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // OrganizationalUnitIdentifiersConfiguration is used to represent an OU

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -775,21 +775,19 @@ Profiles:
                       #
                       # This can be encoded using the following schemas.
                       # It will be parsed according to the first schema that succeed according to the following order.
-                      # - JSON.
                       # - YAML.
+                      # - JSON.
                       # - [id=ID,][broadcast,][deliver,][host=Host,][port=Port,][Host:Port].
                       #
                       # Following are examples of encoding host=localhost, port=7050, ID=0, API=broadcast,deliver:
                       # - localhost:7050
                       # - id=0,broadcast,deliver,localhost:7050
                       # - id=0,broadcast,deliver,host=localhost,port=7050
-                      # - {"host": "localhost", "port": 7050]}
-                      # - {"host": "localhost", "port": 7050, "id": 0, "api": ["broadcast", "deliver"]}
-                      # - -|
-                      #   host: localhost
+                      # - {host: "localhost", port: 7050]}
+                      # - {host: "localhost", port: 7050, id: 0, api: ["broadcast", "deliver"]}
+                      # - host: localhost
                       #   port: 7050
-                      # - -|
-                      #   host: localhost
+                      # - host: localhost
                       #   port: 7050
                       #   id: 0
                       #   api:
@@ -799,14 +797,20 @@ Profiles:
                       # Following are examples of encoding host=localhost, port=7050, ID=5, API=deliver:
                       # - id=5,deliver,localhost:7050
                       # - id=5,deliver,host=localhost,port=7050
-                      # - {"host": "localhost", "port": 7050, "id": 5, "api": ["deliver"]}
-                      # - -|
-                      #   host: localhost
+                      # - {host: "localhost", port: 7050, id: 5, api: ["deliver"]}
+                      # - host: localhost
                       #   port: 7050
                       #   id: 5
                       #   api: [ "deliver" ]
-                      - id=0,broadcast,localhost:7050
-                      - id=0,deliver,localhost:7060
+                      - id=0,broadcast,orderer-1:7050
+                      - id=0,deliver,orderer-1:7060
+                      - id: 1
+                        api:
+                            - broadcast
+                            - deliver
+                        host: orderer-2
+                        port: 7050
+                      - {id: 2, host: "orderer-3", port: 7050}
 
         Application:
             <<: *ApplicationDefaults


### PR DESCRIPTION
#### Type of change

- Improvement

#### Description

- Add Orderer endpoint to profile
  - Allow giving Orderer endpoint as pure YAML
  - Allow reuse of parsing code by other components
- Add test
- Update sample
- Export reusable viper decoding hooks
- Fix lint issues
- Upgrade to `yaml.v3`
