### PR TITLE
[cryptogen] Add SANS support for CreateDefaultConfigBlockWithCrypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ lint-proto: FORCE $(PROTOS_SENTINEL)
 		--config .apilinter.yaml \
 		--set-exit-status \
 		--output-format github \
-		$(shell find ${project_dir}/api -name '*.proto' -exec realpath --relative-to ${project_dir}/api {} \;)
+		$(shell find ${project_dir}/api -name '*.proto' | sed 's|${project_dir}/api/||')
 
 $(PROTOS_SENTINEL):
 	@echo "Cloning fabric-protos..."

--- a/tools/cryptogen/config_block.go
+++ b/tools/cryptogen/config_block.go
@@ -48,6 +48,7 @@ type Node struct {
 	CommonName string
 	Hostname   string
 	Party      string
+	SANS       []string
 }
 
 // OrdererEndpoint address should be in the format of <host>:<port>, not the full [types.OrdererEndpoint] format.
@@ -181,6 +182,7 @@ func createOrgSpec(o *OrganizationParameters) OrgSpec {
 		nodeSpecs = append(nodeSpecs, NodeSpec{
 			CommonName:         n.CommonName,
 			Hostname:           n.Hostname,
+			SANS:               n.SANS,
 			Party:              n.Party,
 			OrganizationalUnit: OrdererOU,
 		})
@@ -189,6 +191,7 @@ func createOrgSpec(o *OrganizationParameters) OrgSpec {
 		nodeSpecs = append(nodeSpecs, NodeSpec{
 			CommonName:         n.CommonName,
 			Hostname:           n.Hostname,
+			SANS:               n.SANS,
 			Party:              n.Party,
 			OrganizationalUnit: OrdererOU,
 		})
@@ -197,6 +200,7 @@ func createOrgSpec(o *OrganizationParameters) OrgSpec {
 		nodeSpecs = append(nodeSpecs, NodeSpec{
 			CommonName:         n.CommonName,
 			Hostname:           n.Hostname,
+			SANS:               n.SANS,
 			Party:              n.Party,
 			OrganizationalUnit: PeerOU,
 		})


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

- Add SANS support for CreateDefaultConfigBlockWithCrypto.
This is required to allow defining the nodes' TLS certificates with all relevant server endpoints.
This will enable us to properly test TLS connections with the CAs specified in the config block.

#### Related issues

- resolves #59 
- required for https://github.com/hyperledger/fabric-x-committer/issues/247
