### PR TITLE
[cryptogen] Add a constant for the config block file name

### DIFF
--- a/tools/cryptogen/config_block.go
+++ b/tools/cryptogen/config_block.go
@@ -57,9 +57,11 @@ type OrdererEndpoint struct {
 	API     []string
 }
 
+// file names.
 const (
-	metaNamespaceFile = "meta-namespace-cert.pem"
-	armaDataFile      = "arma.pb.bin"
+	ConfigBlockFileName = "config-block.pb.bin"
+	metaNamespaceFile   = "meta-namespace-cert.pem"
+	armaDataFile        = "arma.pb.bin"
 )
 
 // LoadSampleConfig returns the orderer/application config combination that corresponds to
@@ -157,7 +159,7 @@ func CreateDefaultConfigBlockWithCrypto(conf ConfigBlockParameters) (*common.Blo
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get output block")
 	}
-	err = configtxgen.WriteOutputBlock(block, path.Join(conf.TargetPath, "config-block.pb.bin"))
+	err = configtxgen.WriteOutputBlock(block, path.Join(conf.TargetPath, ConfigBlockFileName))
 	return block, errors.Wrap(err, "failed to write block")
 }
 

--- a/tools/cryptogen/config_block_test.go
+++ b/tools/cryptogen/config_block_test.go
@@ -68,7 +68,7 @@ func TestMakeConfig(t *testing.T) {
 		expectedDirs = append(expectedDirs, filepath.Join(org2Dir, "orderers", n, "msp"))
 	}
 
-	test.RequireTree(t, target, []string{"config-block.pb.bin"}, expectedDirs)
+	test.RequireTree(t, target, []string{ConfigBlockFileName}, expectedDirs)
 
 	bundle := readBundle(t, block)
 	oc, ok := bundle.OrdererConfig()


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

- Add a constant for the config block file name in the cryptogen tool
This is useful for internal and external testing.