### PR TITLE
[blockstore] add AddBlockNoSync and Flush API

### DIFF
--- a/common/ledger/blkstorage/blockfile_rw.go
+++ b/common/ledger/blkstorage/blockfile_rw.go
@@ -47,6 +47,10 @@ func (w *blockfileWriter) append(b []byte, sync bool) error {
 	return nil
 }
 
+func (w *blockfileWriter) sync() error {
+	return w.file.Sync()
+}
+
 func (w *blockfileWriter) open() error {
 	file, err := os.OpenFile(w.filePath, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0o660)
 	if err != nil {

--- a/common/ledger/blkstorage/blockindex.go
+++ b/common/ledger/blkstorage/blockindex.go
@@ -81,7 +81,7 @@ func (index *blockIndex) getLastBlockIndexed() (uint64, error) {
 	return decodeBlockNum(blockNumBytes), nil
 }
 
-func (index *blockIndex) indexBlock(blockIdxInfo *blockIdxInfo) error {
+func (index *blockIndex) indexBlock(blockIdxInfo *blockIdxInfo, sync bool) error {
 	// do not index anything
 	if len(index.indexItemsMap) == 0 {
 		logger.Debug("Not indexing block... as nothing to index")
@@ -140,11 +140,7 @@ func (index *blockIndex) indexBlock(blockIdxInfo *blockIdxInfo) error {
 	}
 
 	batch.Put(indexSavePointKey, encodeBlockNum(blockIdxInfo.blockNum))
-	// Setting snyc to true as a precaution, false may be an ok optimization after further testing.
-	if err := index.db.WriteBatch(batch, true); err != nil {
-		return err
-	}
-	return nil
+	return index.db.WriteBatch(batch, sync)
 }
 
 func (index *blockIndex) isAttributeIndexed(attribute IndexableAttr) bool {

--- a/common/ledger/blockledger/fileledger/impl_test.go
+++ b/common/ledger/blockledger/fileledger/impl_test.go
@@ -68,6 +68,14 @@ func (mbs *mockBlockStore) AddBlock(block *cb.Block) error {
 	return mbs.defaultError
 }
 
+func (mbs *mockBlockStore) AddBlockNoSync(*cb.Block) error {
+	return mbs.defaultError
+}
+
+func (mbs *mockBlockStore) Flush() error {
+	return mbs.defaultError
+}
+
 func (mbs *mockBlockStore) GetBlockchainInfo() (*cb.BlockchainInfo, error) {
 	return mbs.blockchainInfo, mbs.getBlockchainInfoError
 }

--- a/common/ledger/blockledger/fileledger/mock/file_ledger_block_store.go
+++ b/common/ledger/blockledger/fileledger/mock/file_ledger_block_store.go
@@ -20,6 +20,27 @@ type FileLedgerBlockStore struct {
 	addBlockReturnsOnCall map[int]struct {
 		result1 error
 	}
+	AddBlockNoSyncStub        func(*common.Block) error
+	addBlockNoSyncMutex       sync.RWMutex
+	addBlockNoSyncArgsForCall []struct {
+		arg1 *common.Block
+	}
+	addBlockNoSyncReturns struct {
+		result1 error
+	}
+	addBlockNoSyncReturnsOnCall map[int]struct {
+		result1 error
+	}
+	FlushStub        func() error
+	flushMutex       sync.RWMutex
+	flushArgsForCall []struct {
+	}
+	flushReturns struct {
+		result1 error
+	}
+	flushReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetBlockchainInfoStub        func() (*common.BlockchainInfo, error)
 	getBlockchainInfoMutex       sync.RWMutex
 	getBlockchainInfoArgsForCall []struct {
@@ -123,6 +144,120 @@ func (fake *FileLedgerBlockStore) AddBlockReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.addBlockReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FileLedgerBlockStore) AddBlockNoSync(arg1 *common.Block) error {
+	fake.addBlockNoSyncMutex.Lock()
+	ret, specificReturn := fake.addBlockNoSyncReturnsOnCall[len(fake.addBlockNoSyncArgsForCall)]
+	fake.addBlockNoSyncArgsForCall = append(fake.addBlockNoSyncArgsForCall, struct {
+		arg1 *common.Block
+	}{arg1})
+	stub := fake.AddBlockNoSyncStub
+	fakeReturns := fake.addBlockNoSyncReturns
+	fake.recordInvocation("AddBlockNoSync", []interface{}{arg1})
+	fake.addBlockNoSyncMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FileLedgerBlockStore) AddBlockNoSyncCallCount() int {
+	fake.addBlockNoSyncMutex.RLock()
+	defer fake.addBlockNoSyncMutex.RUnlock()
+	return len(fake.addBlockNoSyncArgsForCall)
+}
+
+func (fake *FileLedgerBlockStore) AddBlockNoSyncCalls(stub func(*common.Block) error) {
+	fake.addBlockNoSyncMutex.Lock()
+	defer fake.addBlockNoSyncMutex.Unlock()
+	fake.AddBlockNoSyncStub = stub
+}
+
+func (fake *FileLedgerBlockStore) AddBlockNoSyncArgsForCall(i int) *common.Block {
+	fake.addBlockNoSyncMutex.RLock()
+	defer fake.addBlockNoSyncMutex.RUnlock()
+	argsForCall := fake.addBlockNoSyncArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FileLedgerBlockStore) AddBlockNoSyncReturns(result1 error) {
+	fake.addBlockNoSyncMutex.Lock()
+	defer fake.addBlockNoSyncMutex.Unlock()
+	fake.AddBlockNoSyncStub = nil
+	fake.addBlockNoSyncReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FileLedgerBlockStore) AddBlockNoSyncReturnsOnCall(i int, result1 error) {
+	fake.addBlockNoSyncMutex.Lock()
+	defer fake.addBlockNoSyncMutex.Unlock()
+	fake.AddBlockNoSyncStub = nil
+	if fake.addBlockNoSyncReturnsOnCall == nil {
+		fake.addBlockNoSyncReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addBlockNoSyncReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FileLedgerBlockStore) Flush() error {
+	fake.flushMutex.Lock()
+	ret, specificReturn := fake.flushReturnsOnCall[len(fake.flushArgsForCall)]
+	fake.flushArgsForCall = append(fake.flushArgsForCall, struct {
+	}{})
+	stub := fake.FlushStub
+	fakeReturns := fake.flushReturns
+	fake.recordInvocation("Flush", []interface{}{})
+	fake.flushMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FileLedgerBlockStore) FlushCallCount() int {
+	fake.flushMutex.RLock()
+	defer fake.flushMutex.RUnlock()
+	return len(fake.flushArgsForCall)
+}
+
+func (fake *FileLedgerBlockStore) FlushCalls(stub func() error) {
+	fake.flushMutex.Lock()
+	defer fake.flushMutex.Unlock()
+	fake.FlushStub = stub
+}
+
+func (fake *FileLedgerBlockStore) FlushReturns(result1 error) {
+	fake.flushMutex.Lock()
+	defer fake.flushMutex.Unlock()
+	fake.FlushStub = nil
+	fake.flushReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FileLedgerBlockStore) FlushReturnsOnCall(i int, result1 error) {
+	fake.flushMutex.Lock()
+	defer fake.flushMutex.Unlock()
+	fake.FlushStub = nil
+	if fake.flushReturnsOnCall == nil {
+		fake.flushReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.flushReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

This commit adds two new APIs to the block storage to allow async writes. While the orderer can use the sync writes, the sidecar component in the committer can use these APIs to periodically sync the writes to block store. This can improve the block store write performance by 7x.

cpu: Apple M4 Max
BenchmarkAddBlock/Sync-14              100  10876240 ns/op
BenchmarkAddBlock/NoSync-14            760   1722055 ns/op
