### PR TITLE
remove MetaNamespaceVerificationKey

### DIFF
--- a/common/channelconfig/application.go
+++ b/common/channelconfig/application.go
@@ -8,7 +8,6 @@ package channelconfig
 
 import (
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
-	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
 	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/pkg/errors"
 
@@ -21,15 +20,12 @@ const (
 
 	// ACLsKey is the name of the ACLs config
 	ACLsKey = "ACLs"
-
-	MetaNamespaceVerificationKey = "MetaNamespaceVerificationKey"
 )
 
 // ApplicationProtos is used as the source of the ApplicationConfig
 type ApplicationProtos struct {
-	ACLs                         *pb.ACLs
-	Capabilities                 *cb.Capabilities
-	MetaNamespaceVerificationKey *msp.KeyInfo
+	ACLs         *pb.ACLs
+	Capabilities *cb.Capabilities
 }
 
 // ApplicationConfig implements the Application interface
@@ -81,9 +77,4 @@ func (ac *ApplicationConfig) APIPolicyMapper() PolicyMapper {
 	pm := newAPIsProvider(ac.protos.ACLs.Acls)
 
 	return pm
-}
-
-// MetaNamespaceVerificationKey returns the meta-namespace verification key
-func (ac *ApplicationConfig) MetaNamespaceVerificationKey() *msp.KeyInfo {
-	return ac.protos.MetaNamespaceVerificationKey
 }

--- a/common/channelconfig/util.go
+++ b/common/channelconfig/util.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package channelconfig
 
 import (
-	"crypto/x509"
 	"fmt"
 	"math"
 	"os"
@@ -182,16 +181,6 @@ func CapabilitiesValue(capabilities map[string]bool) *StandardConfigValue {
 	return &StandardConfigValue{
 		key:   CapabilitiesKey,
 		value: c,
-	}
-}
-
-func MetaNamespaceVerificationKeyValue(key []byte) *StandardConfigValue {
-	return &StandardConfigValue{
-		key: MetaNamespaceVerificationKey,
-		// We use existing proto here to avoid introducing new once.
-		// So we encode the key schema as the identifier.
-		// This will be replaced in the future with a generic policy mechanism.
-		value: &mspprotos.KeyInfo{KeyIdentifier: x509.ECDSA.String(), KeyMaterial: key},
 	}
 }
 

--- a/protolator/protoext/peerext/configuration.go
+++ b/protolator/protoext/peerext/configuration.go
@@ -105,8 +105,6 @@ func (ccv *DynamicApplicationConfigValue) StaticallyOpaqueFieldProto(name string
 		return &common.Capabilities{}, nil
 	case "ACLs":
 		return &peer.ACLs{}, nil
-	case "MetaNamespaceVerificationKey":
-		return &msp.KeyInfo{}, nil
 	default:
 		return nil, fmt.Errorf("Unknown Application ConfigValue name: %s", ccv.name)
 	}

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -807,10 +807,6 @@ Profiles:
 
         Application: &FabricXApplicationDefaults
             <<: *ApplicationDefaults
-            # This certificate is used to validate meta-namespace transactions.
-            # This is a temporary solution (fabric-x). It will be removed once the committer will support MSP policies.
-            # The matching private key can be found under crypto/SampleOrg/msp/keystore/key.pem
-            MetaNamespaceVerificationKeyPath: crypto/SampleOrg/msp/admincerts/admincert.pem
             Organizations:
                 - <<: *SampleOrg
 

--- a/tools/configtxgen/config.go
+++ b/tools/configtxgen/config.go
@@ -118,11 +118,10 @@ type Consortium struct {
 // Application encodes the application-level configuration needed in config
 // transactions.
 type Application struct {
-	Organizations                    []*Organization    `yaml:"Organizations"`
-	Capabilities                     map[string]bool    `yaml:"Capabilities"`
-	Policies                         map[string]*Policy `yaml:"Policies"`
-	ACLs                             map[string]string  `yaml:"ACLs"`
-	MetaNamespaceVerificationKeyPath string             `yaml:"MetaNamespaceVerificationKeyPath"`
+	Organizations []*Organization    `yaml:"Organizations"`
+	Capabilities  map[string]bool    `yaml:"Capabilities"`
+	Policies      map[string]*Policy `yaml:"Policies"`
+	ACLs          map[string]string  `yaml:"ACLs"`
 }
 
 // Organization encodes the organization-level configuration needed in
@@ -305,9 +304,6 @@ func (p *Profile) CompleteInitialization(configDir string) {
 	if p.Application != nil {
 		for _, org := range p.Application.Organizations {
 			org.completeInitialization(configDir)
-		}
-		if p.Application.MetaNamespaceVerificationKeyPath != "" {
-			cf.TranslatePathInPlace(configDir, &p.Application.MetaNamespaceVerificationKeyPath)
 		}
 	}
 

--- a/tools/configtxgen/tools_test.go
+++ b/tools/configtxgen/tools_test.go
@@ -170,7 +170,6 @@ func TestBftOrdererTypeWithV3CapabilitiesShouldNotRaiseAnError(t *testing.T) {
 func TestFabricXGenesisBlock(t *testing.T) {
 	t.Parallel()
 
-	keyPath := filepath.Join(configtest.GetDevConfigDir(), "crypto", "SampleOrg", "msp", "signcerts", "peer.pem")
 	allAPI := []string{types.Broadcast, types.Deliver}
 
 	for _, tc := range []struct {
@@ -199,7 +198,6 @@ func TestFabricXGenesisBlock(t *testing.T) {
 			t.Parallel()
 			blockDest := filepath.Join(t.TempDir(), "block")
 			config := Load(tc.sample, configtest.GetDevConfigDir())
-			config.Application.MetaNamespaceVerificationKeyPath = keyPath
 			armaPath := filepath.Join(configtest.GetDevConfigDir(), "arma_shared_config.pbbin")
 			config.Orderer.Arma.Path = armaPath
 			require.NoError(t, DoOutputBlock(config, "foo", blockDest))

--- a/tools/cryptogen/config_block.go
+++ b/tools/cryptogen/config_block.go
@@ -24,12 +24,11 @@ import (
 
 // ConfigBlockParameters represents the configuration of the config block.
 type ConfigBlockParameters struct {
-	TargetPath                   string
-	BaseProfile                  string
-	ChannelID                    string
-	Organizations                []OrganizationParameters
-	MetaNamespaceVerificationKey []byte
-	ArmaMetaBytes                []byte
+	TargetPath    string
+	BaseProfile   string
+	ChannelID     string
+	Organizations []OrganizationParameters
+	ArmaMetaBytes []byte
 }
 
 // OrganizationParameters represents the properties of an organization.
@@ -60,7 +59,6 @@ type OrdererEndpoint struct {
 // file names.
 const (
 	ConfigBlockFileName = "config-block.pb.bin"
-	metaNamespaceFile   = "meta-namespace-cert.pem"
 	armaDataFile        = "arma.pb.bin"
 )
 
@@ -137,11 +135,6 @@ func CreateDefaultConfigBlockWithCrypto(conf ConfigBlockParameters) (*common.Blo
 		}
 	}
 
-	err = os.WriteFile(path.Join(conf.TargetPath, metaNamespaceFile), conf.MetaNamespaceVerificationKey, 0o644)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to write meta namespace file")
-	}
-	profile.Application.MetaNamespaceVerificationKeyPath = metaNamespaceFile
 	err = os.WriteFile(path.Join(conf.TargetPath, armaDataFile), conf.ArmaMetaBytes, 0o644)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to write ARMA data file")

--- a/tools/cryptogen/config_block_test.go
+++ b/tools/cryptogen/config_block_test.go
@@ -9,7 +9,6 @@ package cryptogen
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/pem"
 	"net"
 	"os"
 	"path"
@@ -347,11 +346,6 @@ func defaultConfigBlock(t *testing.T) (
 	target = t.TempDir()
 	armaData = []byte("fake-arma-data")
 
-	key, err := generatePrivateKey(target, ECDSA)
-	require.NoError(t, err)
-	certBytes, err := x509.MarshalPKIXPublicKey(getPublicKey(key))
-	require.NoError(t, err)
-	metaKeyBytes := pem.EncodeToMemory(&pem.Block{Type: CertType, Bytes: certBytes})
 	p := ConfigBlockParameters{
 		TargetPath: target,
 		ChannelID:  "my-chan",
@@ -413,10 +407,10 @@ func defaultConfigBlock(t *testing.T) (
 				},
 			},
 		},
-		ArmaMetaBytes:                armaData,
-		MetaNamespaceVerificationKey: metaKeyBytes,
+		ArmaMetaBytes: armaData,
 	}
 
+	var err error
 	block, err = CreateDefaultConfigBlockWithCrypto(p)
 	require.NoError(t, err)
 	require.NotNil(t, block)


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

As we are planning to use LifecycleEndorsementPolicy instead of MetaNamespaceVerificationKey, we can remove it from the config block.

#### Related issues
 
  - resolves #58 