### PR TITLE
Restore PeerPropose ACL resource and remove ACL capability gates

### DIFF
--- a/common/capabilities/application.go
+++ b/common/capabilities/application.go
@@ -69,9 +69,10 @@ func (ap *ApplicationProvider) Type() string {
 	return applicationTypeName
 }
 
-// ACLs returns whether ACLs may be specified in the channel application config
+// ACLs returns whether ACLs may be specified in the channel application config.
+// In Fabric-X, ACLs are always allowed regardless of capability version.
 func (ap *ApplicationProvider) ACLs() bool {
-	return ap.v12 || ap.v13 || ap.v142 || ap.v20 || ap.v25
+	return true
 }
 
 // ForbidDuplicateTXIdInBlock specifies whether two transactions with the same TXId are permitted

--- a/common/capabilities/application_test.go
+++ b/common/capabilities/application_test.go
@@ -16,6 +16,8 @@ import (
 func TestApplicationV10(t *testing.T) {
 	ap := NewApplicationProvider(map[string]*cb.Capability{})
 	require.NoError(t, ap.Supported())
+	// ACLs are always enabled in Fabric-X, regardless of capability version
+	require.True(t, ap.ACLs())
 }
 
 func TestApplicationV11(t *testing.T) {
@@ -25,6 +27,8 @@ func TestApplicationV11(t *testing.T) {
 	require.NoError(t, ap.Supported())
 	require.True(t, ap.ForbidDuplicateTXIdInBlock())
 	require.True(t, ap.V1_1Validation())
+	// ACLs are always enabled in Fabric-X, regardless of capability version
+	require.True(t, ap.ACLs())
 }
 
 func TestApplicationV12(t *testing.T) {

--- a/common/channelconfig/application.go
+++ b/common/channelconfig/application.go
@@ -45,12 +45,6 @@ func NewApplicationConfig(appGroup *cb.ConfigGroup, mspConfig *MSPConfigHandler)
 		return nil, errors.Wrap(err, "failed to deserialize values")
 	}
 
-	if !ac.Capabilities().ACLs() {
-		if _, ok := appGroup.Values[ACLsKey]; ok {
-			return nil, errors.New("ACLs may not be specified without the required capability")
-		}
-	}
-
 	var err error
 	for orgName, orgGroup := range appGroup.Groups {
 		ac.applicationOrgs[orgName], err = NewApplicationOrgConfig(orgName, orgGroup, mspConfig)

--- a/common/channelconfig/application_test.go
+++ b/common/channelconfig/application_test.go
@@ -18,10 +18,12 @@ import (
 )
 
 func TestApplicationInterface(t *testing.T) {
+	t.Parallel()
 	_ = Application((*ApplicationConfig)(nil))
 }
 
 func TestACL(t *testing.T) {
+	t.Parallel()
 	g := NewGomegaWithT(t)
 	cgt := &cb.ConfigGroup{
 		Values: map[string]*cb.ConfigValue{
@@ -41,15 +43,17 @@ func TestACL(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
 		cg := proto.Clone(cgt).(*cb.ConfigGroup)
 		_, err := NewApplicationConfig(proto.Clone(cg).(*cb.ConfigGroup), nil)
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 
-	t.Run("MissingCapability", func(t *testing.T) {
+	t.Run("ACLsAllowedWithoutCapability", func(t *testing.T) {
+		t.Parallel()
 		cg := proto.Clone(cgt).(*cb.ConfigGroup)
 		delete(cg.Values, CapabilitiesKey)
 		_, err := NewApplicationConfig(cg, nil)
-		g.Expect(err).To(MatchError("ACLs may not be specified without the required capability"))
+		g.Expect(err).NotTo(HaveOccurred())
 	})
 }

--- a/core/aclmgmt/defaultaclprovider.go
+++ b/core/aclmgmt/defaultaclprovider.go
@@ -13,6 +13,7 @@ import (
 	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
 
 	"github.com/hyperledger/fabric-x-common/common/policies"
+	"github.com/hyperledger/fabric-x-common/core/aclmgmt/resources"
 	"github.com/hyperledger/fabric-x-common/core/policy"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 )
@@ -45,6 +46,9 @@ func newDefaultACLProvider(policyChecker policy.PolicyChecker) defaultACLProvide
 		pResourcePolicyMap: map[string]string{},
 		cResourcePolicyMap: map[string]string{},
 	}
+
+	// Peer resources
+	d.cResourcePolicyMap[resources.Peer_Propose] = CHANNELWRITERS
 
 	return d
 }

--- a/core/aclmgmt/resources/resources.go
+++ b/core/aclmgmt/resources/resources.go
@@ -6,3 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 // Package resources contains resource names used in fabric for ACL checks.
 package resources
+
+const (
+	// Peer_Propose is the ACL resource for the peer Propose API.
+	// The underscore naming is intentional to preserve compatibility with
+	// downstream consumers (e.g., fabric-smart-client) that reference this constant.
+	Peer_Propose = "peer/Propose" //nolint:revive,staticcheck
+)

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -155,6 +155,13 @@ Capabilities:
 #
 ################################################################################
 Application: &ApplicationDefaults
+    ACLs:
+        # This section provides defaults for policies for various resources
+        # in the system. This section does NOT specify the resource's
+        # definition or API, but just the ACL policy for it.
+        # Users can override these defaults using the ACLs section in their channel definition
+        peer/Propose: /Channel/Application/Writers
+
     # Organizations lists the orgs participating on the application side of the
     # network.
     Organizations:


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Commit c948ab27e removed all ACL resource constants and default policy mappings, but fabric-smart-client's fabricx membership service still depends on:

  - resources.Peer_Propose constant ("peer/Propose")
  - default ACL mapping Peer_Propose → CHANNELWRITERS
  - aclmgmt.ACLProvider / aclmgmt.NewACLProvider

Without these, FSC fails to compile and CheckACL would hit "Unmapped policy" at runtime.

Additionally, remove the capability gate that rejected ACLs when the application capability version was below V1_2. In Fabric-X, ACLs are always allowed regardless of capability version.

Changes:
  - core/aclmgmt/resources/resources.go: restore Peer_Propose constant
  - core/aclmgmt/defaultaclprovider.go: restore Peer_Propose → CHANNELWRITERS mapping
  - common/capabilities/application.go: ACLs() always returns true
  - common/channelconfig/application.go: remove capability validation gate
  - Update tests for always-allowed ACLs
