### PR TITLE
Fix newest iterator on empty file ledger

### DIFF
--- a/common/ledger/blockledger/fileledger/impl.go
+++ b/common/ledger/blockledger/fileledger/impl.go
@@ -80,7 +80,10 @@ func (fl *FileLedger) Iterator(startPosition *ab.SeekPosition) (blockledger.Iter
 		if err != nil {
 			logger.Panic(err)
 		}
-		newestBlockNumber := info.Height - 1
+		newestBlockNumber := uint64(0)
+		if info.Height > 0 {
+			newestBlockNumber = info.Height - 1
+		}
 		if info.BootstrappingSnapshotInfo != nil && newestBlockNumber == info.BootstrappingSnapshotInfo.LastBlockInSnapshot {
 			newestBlockNumber = info.Height
 		}

--- a/common/ledger/blockledger/fileledger/impl_test.go
+++ b/common/ledger/blockledger/fileledger/impl_test.go
@@ -63,6 +63,7 @@ type mockBlockStore struct {
 	defaultError               error
 	getBlockchainInfoError     error
 	retrieveBlockByNumberError error
+	retrieveBlocksStart        uint64
 }
 
 func (mbs *mockBlockStore) AddBlock(block *cb.Block) error {
@@ -81,7 +82,8 @@ func (mbs *mockBlockStore) GetBlockchainInfo() (*cb.BlockchainInfo, error) {
 	return mbs.blockchainInfo, mbs.getBlockchainInfoError
 }
 
-func (mbs *mockBlockStore) RetrieveBlocks(_ uint64) (cl.ResultsIterator, error) {
+func (mbs *mockBlockStore) RetrieveBlocks(startBlockNumber uint64) (cl.ResultsIterator, error) {
+	mbs.retrieveBlocksStart = startBlockNumber
 	return mbs.resultsIterator, mbs.defaultError
 }
 
@@ -322,6 +324,27 @@ func TestBlockRetrievalWithSnapshot(t *testing.T) {
 	blk, status = it3.Next(t.Context())
 	require.Equal(t, cb.Status_SUCCESS, status)
 	require.Equal(t, nextBlk, blk)
+}
+
+func TestNewestIteratorOnEmptyLedgerStartsAtBlockZero(t *testing.T) {
+	t.Parallel()
+
+	resultsIterator := &mockBlockStoreIterator{}
+	resultsIterator.On("Close").Return()
+	blockStore := &mockBlockStore{
+		blockchainInfo:  &cb.BlockchainInfo{Height: 0},
+		resultsIterator: resultsIterator,
+	}
+	fl := &FileLedger{
+		blockStore: blockStore,
+		signal:     make(chan struct{}),
+	}
+
+	it, startingNum := fl.Iterator(&ab.SeekPosition{Type: &ab.SeekPosition_Newest{}})
+	defer it.Close()
+
+	require.Zero(t, startingNum)
+	require.Zero(t, blockStore.retrieveBlocksStart)
 }
 
 func TestBlockstoreError(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

When `SeekPosition_Newest` is used on an empty `FileLedger`, `Iterator` computed `Height - 1`, underflowing to `math.MaxUint64`. This makes the iterator request an impossible block number instead of waiting from block zero.

- Guard newest seek when ledger height is zero
- Start empty-ledger newest iterators at block zero
- Add regression coverage for the empty-ledger case

#### Related

Companion for hyperledger/fabric-x-committer#601.