### PR TITLE
configtx: add SnapshotEndorsement and CheckpointEndorsement application policies

### DIFF
--- a/docs/configtx.md
+++ b/docs/configtx.md
@@ -343,6 +343,12 @@ Application: &ApplicationDefaults
     LifecycleEndorsement:
       Type: ImplicitMeta
       Rule: MAJORITY Endorsement
+    SnapshotEndorsement:
+      Type: ImplicitMeta
+      Rule: MAJORITY Endorsement
+    CheckpointEndorsement:
+      Type: ImplicitMeta
+      Rule: MAJORITY Endorsement
     Endorsement:
       Type: ImplicitMeta
       Rule: MAJORITY Endorsement
@@ -399,8 +405,14 @@ endorsements by default.
 Each namespace has its own policy (`NamespacePolicy`) that governs
 transaction validation within that namespace. A `NamespacePolicy` can use
 either:
+
 - A **ThresholdRule** with a signature scheme and public key, or
 - An **MSP rule** (raw MSP policy bytes)
+
+`SnapshotEndorsement` and `CheckpointEndorsement` follow the same
+`ImplicitMeta` channel-policy pattern as `LifecycleEndorsement`, resolved from
+`/Channel/Application/SnapshotEndorsement` and
+`/Channel/Application/CheckpointEndorsement` respectively.
 
 ```
 NamespacePolicy
@@ -618,6 +630,7 @@ Profiles are the **entry point** for `configtxgen`. A profile composes the
 templates from the top-level sections into a complete network definition.
 
 A Fabric-X genesis block profile must include:
+
 - An `Orderer` section (with organizations, ConsenterMapping, and Arma config)
 - An `Application` section (with organizations and lifecycle endorsement policy)
 - Channel-level policies
@@ -842,6 +855,7 @@ SharedConfig (binary protobuf)
 
 Fabric-X introduces a richer orderer endpoint format compared to legacy Fabric.
 Each endpoint can specify:
+
 - A **party ID** identifying which ordering party it belongs to
 - A specific **API** it supports (`broadcast`, `deliver`, or both)
 
@@ -1063,20 +1077,22 @@ the policy path that governs it. A failed config update usually points at an
 `/Channel/Orderer/BlockValidation`.
 
 ```
-/Channel/Readers                        Network-level read access (Deliver API)
-/Channel/Writers                        Network-level write access (Broadcast API)
-/Channel/Admins                         Network-level admin (config updates)
-/Channel/Orderer/Readers                Orderer read access
-/Channel/Orderer/Writers                Orderer write access
-/Channel/Orderer/Admins                 Orderer admin
-/Channel/Orderer/BlockValidation        Block signature verification
-/Channel/Application/Readers            Application read access
-/Channel/Application/Writers            Application write access
-/Channel/Application/Admins             Application admin
+/Channel/Readers                            Network-level read access (Deliver API)
+/Channel/Writers                            Network-level write access (Broadcast API)
+/Channel/Admins                             Network-level admin (config updates)
+/Channel/Orderer/Readers                    Orderer read access
+/Channel/Orderer/Writers                    Orderer write access
+/Channel/Orderer/Admins                     Orderer admin
+/Channel/Orderer/BlockValidation            Block signature verification
+/Channel/Application/Readers                Application read access
+/Channel/Application/Writers                Application write access
+/Channel/Application/Admins                 Application admin
 /Channel/Application/LifecycleEndorsement   Chaincode lifecycle endorsement
-/Channel/Application/Endorsement        Chaincode execution endorsement
-/Channel/Orderer/<OrgName>/Readers      Per-org orderer policies
-/Channel/Application/<OrgName>/Readers  Per-org application policies
+/Channel/Application/SnapshotEndorsement    Snapshot transaction authorization
+/Channel/Application/CheckpointEndorsement  Checkpoint transaction authorization
+/Channel/Application/Endorsement            Chaincode execution endorsement
+/Channel/Orderer/<OrgName>/Readers          Per-org orderer policies
+/Channel/Application/<OrgName>/Readers      Per-org application policies
 ```
 
 ### 8.5 ACLs (Future)
@@ -1375,11 +1391,13 @@ Channel/                                           (root ConfigGroup)
     |
     +-- Application/
         +-- Policies/
-        |   +-- Readers              ImplicitMeta "ANY Readers"
-        |   +-- Writers              ImplicitMeta "ANY Writers"
-        |   +-- Admins               ImplicitMeta "MAJORITY Admins"
-        |   +-- LifecycleEndorsement ImplicitMeta "MAJORITY Endorsement"
-        |   +-- Endorsement          ImplicitMeta "MAJORITY Endorsement"
+        |   +-- Readers               ImplicitMeta "ANY Readers"
+        |   +-- Writers               ImplicitMeta "ANY Writers"
+        |   +-- Admins                ImplicitMeta "MAJORITY Admins"
+        |   +-- LifecycleEndorsement  ImplicitMeta "MAJORITY Endorsement"
+        |   +-- SnapshotEndorsement   ImplicitMeta "MAJORITY Endorsement"
+        |   +-- CheckpointEndorsement ImplicitMeta "MAJORITY Endorsement"
+        |   +-- Endorsement           ImplicitMeta "MAJORITY Endorsement"
         |
         +-- Values/
         |
@@ -1397,7 +1415,6 @@ Channel/                                           (root ConfigGroup)
 ```
 
 ---
-
 
 ## 12. Step-by-Step Usage Examples
 
@@ -1480,6 +1497,12 @@ Capabilities:
 Application: &ApplicationDefaults
   Policies:
     LifecycleEndorsement:
+      Type: ImplicitMeta
+      Rule: MAJORITY Endorsement
+    SnapshotEndorsement:
+      Type: ImplicitMeta
+      Rule: MAJORITY Endorsement
+    CheckpointEndorsement:
       Type: ImplicitMeta
       Rule: MAJORITY Endorsement
     Endorsement:
@@ -1734,6 +1757,8 @@ Step 5: Builds ConfigGroup hierarchy:
                 +-- Org1/ (MSP + policies)
                 +-- Org2/ (MSP + policies)
                 +-- LifecycleEndorsement policy (MAJORITY Endorsement)
+                +-- SnapshotEndorsement policy (MAJORITY Endorsement)
+                +-- CheckpointEndorsement policy (MAJORITY Endorsement)
 Step 6: Wraps ConfigGroup in ConfigEnvelope -> Envelope -> Block #0
 Step 7: Writes genesis.block (protobuf binary, permissions 0640)
 ```

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -173,6 +173,12 @@ Application: &ApplicationDefaults
         LifecycleEndorsement:
             Type: ImplicitMeta
             Rule: MAJORITY Endorsement
+        SnapshotEndorsement:
+            Type: ImplicitMeta
+            Rule: MAJORITY Endorsement
+        CheckpointEndorsement:
+            Type: ImplicitMeta
+            Rule: MAJORITY Endorsement
         Endorsement:
             Type: ImplicitMeta
             Rule: MAJORITY Endorsement

--- a/utils/testcrypto/testcrypto_test.go
+++ b/utils/testcrypto/testcrypto_test.go
@@ -11,10 +11,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-common/api/types"
+	"github.com/hyperledger/fabric-x-common/common/channelconfig"
 	"github.com/hyperledger/fabric-x-common/msp"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/tools/cryptogen"
 )
 
@@ -597,4 +600,35 @@ func TestIntegrationCryptoWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, cert)
 	}
+}
+
+// TestSnapshotCheckpointPoliciesResolve verifies that the generated config block
+// carries the SnapshotEndorsement and CheckpointEndorsement application policies,
+// mirroring how LifecycleEndorsement is emitted today, and that they resolve via
+// the channel PolicyManager (per contracts/snapshot-policy.md).
+func TestSnapshotCheckpointPoliciesResolve(t *testing.T) {
+	t.Parallel()
+	cryptoPath := t.TempDir()
+
+	block, err := CreateOrExtendConfigBlockWithCrypto(cryptoPath, &ConfigBlock{
+		ChannelID:             "test-channel",
+		PeerOrganizationCount: 1,
+		OrdererEndpoints:      []*types.OrdererEndpoint{{ID: 0, Host: "localhost", Port: 7050}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, block)
+
+	envelope, err := protoutil.ExtractEnvelope(block, 0)
+	require.NoError(t, err)
+
+	bundle, err := channelconfig.NewBundleFromEnvelope(envelope, factory.GetDefault())
+	require.NoError(t, err)
+
+	snapshotPolicy, ok := bundle.PolicyManager().GetPolicy("/Channel/Application/SnapshotEndorsement")
+	require.True(t, ok, "SnapshotEndorsement policy not found")
+	require.NotNil(t, snapshotPolicy)
+
+	checkpointPolicy, ok := bundle.PolicyManager().GetPolicy("/Channel/Application/CheckpointEndorsement")
+	require.True(t, ok, "CheckpointEndorsement policy not found")
+	require.NotNil(t, checkpointPolicy)
 }


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

- Add SnapshotEndorsement and CheckpointEndorsement to the Application section of the configtx.yaml template, defaulting to MAJORITY Endorsement (matching the existing LifecycleEndorsement pattern). These are already picked up by the test config-block generator (testcrypto.CreateOrExtendConfigBlockWithCrypto) since it inherits ApplicationDefaults from the sample profile.

- Add TestSnapshotCheckpointPoliciesResolve verifying both policies resolve via bundle.PolicyManager().GetPolicy() at /Channel/Application/SnapshotEndorsement and /Channel/Application/CheckpointEndorsement.

- Update docs/configtx.md to reflect the new policies: canonical policy-path table, config-tree ASCII diagrams (both the conceptual tree and the worked TwoOrgNetwork example), the step-by-step usage example's sample configtx.yaml snippet, and a note clarifying these are config-block channel policies (like LifecycleEndorsement), not per-namespace NamespacePolicy entries. Column-aligns all affected ASCII tables/diagrams, including the pre-existing LifecycleEndorsement row.

#### Related issues

  - resolves #132 