### PR TITLE
Add snapshot/checkpoint MALFORMED status codes

### DIFF
--- a/api/committerpb/status.pb.go
+++ b/api/committerpb/status.pb.go
@@ -57,6 +57,8 @@ const (
 	Status_MALFORMED_MISSING_SIGNATURE               Status = 113 // Number of signatures does not match the number of namespaces.
 	Status_MALFORMED_NAMESPACE_POLICY_INVALID        Status = 114 // Invalid namespace policy.
 	Status_MALFORMED_CONFIG_TX_INVALID               Status = 115 // Invalid configuration transaction.
+	Status_MALFORMED_SNAPSHOT_NOT_MARKER_ONLY        Status = 116 // _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
+	Status_MALFORMED_CHECKPOINT_INVALID_KEY          Status = 117 // _checkpoint TX read-write key does not decode as a valid TxHeight.
 )
 
 // Enum value maps for Status.
@@ -82,6 +84,8 @@ var (
 		113: "MALFORMED_MISSING_SIGNATURE",
 		114: "MALFORMED_NAMESPACE_POLICY_INVALID",
 		115: "MALFORMED_CONFIG_TX_INVALID",
+		116: "MALFORMED_SNAPSHOT_NOT_MARKER_ONLY",
+		117: "MALFORMED_CHECKPOINT_INVALID_KEY",
 	}
 	Status_value = map[string]int32{
 		"STATUS_UNSPECIFIED":                        0,
@@ -104,6 +108,8 @@ var (
 		"MALFORMED_MISSING_SIGNATURE":               113,
 		"MALFORMED_NAMESPACE_POLICY_INVALID":        114,
 		"MALFORMED_CONFIG_TX_INVALID":               115,
+		"MALFORMED_SNAPSHOT_NOT_MARKER_ONLY":        116,
+		"MALFORMED_CHECKPOINT_INVALID_KEY":          117,
 	}
 )
 
@@ -241,7 +247,7 @@ const file_api_committerpb_status_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x03(\v2\x15.committerpb.TxStatusR\x06status\"]\n" +
 	"\bTxStatus\x12$\n" +
 	"\x03ref\x18\x01 \x01(\v2\x12.committerpb.TxRefR\x03ref\x12+\n" +
-	"\x06status\x18\x02 \x01(\x0e2\x13.committerpb.StatusR\x06status*\x88\x05\n" +
+	"\x06status\x18\x02 \x01(\x0e2\x13.committerpb.StatusR\x06status*\xd6\x05\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tCOMMITTED\x10\x01\x12\x1d\n" +
@@ -262,7 +268,9 @@ const file_api_committerpb_status_proto_rawDesc = "" +
 	")MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET\x10p\x12\x1f\n" +
 	"\x1bMALFORMED_MISSING_SIGNATURE\x10q\x12&\n" +
 	"\"MALFORMED_NAMESPACE_POLICY_INVALID\x10r\x12\x1f\n" +
-	"\x1bMALFORMED_CONFIG_TX_INVALID\x10sB8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
+	"\x1bMALFORMED_CONFIG_TX_INVALID\x10s\x12&\n" +
+	"\"MALFORMED_SNAPSHOT_NOT_MARKER_ONLY\x10t\x12$\n" +
+	" MALFORMED_CHECKPOINT_INVALID_KEY\x10uB8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
 
 var (
 	file_api_committerpb_status_proto_rawDescOnce sync.Once

--- a/api/committerpb/status.proto
+++ b/api/committerpb/status.proto
@@ -55,4 +55,6 @@ enum Status {
     MALFORMED_MISSING_SIGNATURE = 113;                  // Number of signatures does not match the number of namespaces.
     MALFORMED_NAMESPACE_POLICY_INVALID = 114;           // Invalid namespace policy.
     MALFORMED_CONFIG_TX_INVALID = 115;                  // Invalid configuration transaction.
+    MALFORMED_SNAPSHOT_NOT_MARKER_ONLY = 116;           // _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
+    MALFORMED_CHECKPOINT_INVALID_KEY = 117;             // _checkpoint TX read-write key does not decode as a valid TxHeight.
 }


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Add two Status enum values to committerpb for sidecar snapshot/checkpoint form validation:

- MALFORMED_SNAPSHOT_NOT_MARKER_ONLY (116): a _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
- MALFORMED_CHECKPOINT_INVALID_KEY (117): a _checkpoint TX read-write key does not decode as a valid TxHeight.

Both are placed in the stored-in-DB MALFORMED block so they carry a valid TX ID and are recorded to block resubmission. No existing enum value is renumbered. Generated status.pb.go regenerated via make proto.
