### PR TITLE
Cryptogen adoption for armageddon

### DIFF
--- a/tools/cryptogen/config_block.go
+++ b/tools/cryptogen/config_block.go
@@ -9,9 +9,11 @@ package cryptogen
 import (
 	"fmt"
 	"maps"
+	"net"
 	"os"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -19,6 +21,7 @@ import (
 
 	"github.com/hyperledger/fabric-x-common/api/types"
 	"github.com/hyperledger/fabric-x-common/common/viperutil"
+	"github.com/hyperledger/fabric-x-common/core/config"
 	"github.com/hyperledger/fabric-x-common/sampleconfig"
 	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
 )
@@ -64,8 +67,8 @@ type Node struct {
 
 // file names.
 const (
-	ConfigBlockFileName = "config-block.pb.bin"
-	armaDataFile        = "arma.pb.bin"
+	ConfigBlockFileName  = "config-block.pb.bin"
+	ArmaSharedConfigFile = "arma.pb.bin"
 )
 
 // LoadSampleConfig returns the orderer/application config combination that corresponds to
@@ -94,7 +97,32 @@ func LoadSampleConfig(profile string) (*configtxgen.Profile, error) {
 // It uses the first orderer organization as a template and creates the given organizations.
 // It uses the same organizations for the orderer and the application.
 func CreateOrExtendConfigBlockWithCrypto(conf ConfigBlockParameters) (*common.Block, error) {
-	initConfigDefault(&conf)
+	profile, err := CreateOrExtendProfileWithCrypto(&conf)
+	if err != nil {
+		return nil, err
+	}
+
+	profile.Orderer.Arma.Path = ArmaSharedConfigFile
+	config.TranslatePathInPlace(conf.TargetPath, &profile.Orderer.Arma.Path)
+
+	err = os.WriteFile(profile.Orderer.Arma.Path, conf.ArmaMetaBytes, 0o644)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to write ARMA data file")
+	}
+
+	block, err := configtxgen.GetOutputBlock(profile, conf.ChannelID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get output block")
+	}
+	err = configtxgen.WriteOutputBlock(block, path.Join(conf.TargetPath, ConfigBlockFileName))
+	return block, errors.Wrap(err, "failed to write block")
+}
+
+// CreateOrExtendProfileWithCrypto creates a profile with default values and a crypto material.
+// It uses the first orderer organization as a template and creates the given organizations.
+// It uses the same organizations for the orderer and the application.
+func CreateOrExtendProfileWithCrypto(conf *ConfigBlockParameters) (*configtxgen.Profile, error) {
+	initConfigDefault(conf)
 	profile, loadErr := LoadSampleConfig(conf.BaseProfile)
 	if loadErr != nil {
 		return nil, loadErr
@@ -142,25 +170,9 @@ func CreateOrExtendConfigBlockWithCrypto(conf ConfigBlockParameters) (*common.Bl
 		}
 	}
 
-	err := os.WriteFile(path.Join(conf.TargetPath, armaDataFile), conf.ArmaMetaBytes, 0o644)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to write ARMA data file")
-	}
-	profile.Orderer.Arma.Path = armaDataFile
-
-	err = Extend(conf.TargetPath, cryptoConf)
-	if err != nil {
-		return nil, err
-	}
-
 	profile.CompleteInitialization(conf.TargetPath)
 
-	block, err := configtxgen.GetOutputBlock(profile, conf.ChannelID)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get output block")
-	}
-	err = configtxgen.WriteOutputBlock(block, path.Join(conf.TargetPath, ConfigBlockFileName))
-	return block, errors.Wrap(err, "failed to write block")
+	return profile, Extend(conf.TargetPath, cryptoConf)
 }
 
 func initConfigDefault(conf *ConfigBlockParameters) {
@@ -269,19 +281,48 @@ func createConsenter(o *OrganizationParameters, ids []uint32) ([]*configtxgen.Co
 		if len(n.PartyName) == 0 && len(ids) > 1 {
 			n.PartyName = fmt.Sprintf("party-%d", id)
 		}
-		identity := path.Join(getOrgPath(o), OrdererNodesDir, n.PartyName, n.CommonName, MSPDir,
-			SignCertsDir, n.CommonName+CertSuffix)
+		host, port, err := parseEndpoint(n.Hostname)
+		if err != nil {
+			return nil, err
+		}
+		identity := path.Join(getOrgPath(o), OrdererNodesDir, n.PartyName, n.CommonName,
+			MSPDir, SignCertsDir, n.CommonName+CertSuffix)
+		tlsIdentity := path.Join(getOrgPath(o), OrdererNodesDir, n.PartyName, n.CommonName,
+			TLSDir, ServerPrefix+".crt")
 		consenter[i] = &configtxgen.Consenter{
 			ID:            id,
-			Host:          n.Hostname,
-			Port:          8080,
+			Host:          host,
+			Port:          port,
 			MSPID:         o.Name,
 			Identity:      identity,
-			ClientTLSCert: identity,
-			ServerTLSCert: identity,
+			ClientTLSCert: tlsIdentity,
+			ServerTLSCert: tlsIdentity,
 		}
 	}
 	return consenter, nil
+}
+
+const defaultEndpointPort = 8080
+
+func parseEndpoint(endpoint string) (string, uint32, error) {
+	if !strings.Contains(endpoint, ":") {
+		return endpoint, defaultEndpointPort, nil
+	}
+	host, portS, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return "", 0, errors.Errorf("endpoint %q is invalid: %w", endpoint, err)
+	}
+	if host == "" {
+		return "", 0, errors.Errorf("endpoint %q must include a host", endpoint)
+	}
+	port, err := strconv.ParseUint(portS, 10, 16) // bit-size 16 rejects ports > 65535
+	if err != nil {
+		return "", 0, errors.Errorf("endpoint %q has an invalid port %q: %w", endpoint, portS, err)
+	}
+	if port == 0 {
+		return "", 0, errors.Errorf("endpoint %q: port must be greater than 0", endpoint)
+	}
+	return host, uint32(port), nil
 }
 
 func getOrgPath(o *OrganizationParameters) string {

--- a/tools/cryptogen/config_block_test.go
+++ b/tools/cryptogen/config_block_test.go
@@ -422,6 +422,11 @@ func requireSign(t *testing.T, bundle *channelconfig.Bundle, policyName string, 
 	require.NoError(t, err)
 }
 
+const (
+	ordererOrgName = "orderer-org"
+	genericOrgName = "generic-org"
+)
+
 var (
 	sans      = []string{"127.0.0.1"}
 	peerNodes = []Node{
@@ -513,4 +518,246 @@ func createBlock(t *testing.T, p ConfigBlockParameters) *common.Block {
 		t.Logf("Actual tree: %s", actualTree)
 	})
 	return block
+}
+
+func TestCreateOrExtendProfileWithCrypto_Defaults(t *testing.T) {
+	// When BaseProfile and ChannelID are empty, initConfigDefault fills them in.
+	t.Parallel()
+	target := t.TempDir()
+	conf := &ConfigBlockParameters{
+		TargetPath: target,
+		// BaseProfile and ChannelID intentionally left empty → defaults applied.
+		Organizations: []OrganizationParameters{
+			{
+				Name:   ordererOrgName,
+				Domain: ordererOrgName + ".com",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					{ID: 1, Host: "localhost", Port: 7050, API: []string{types.Broadcast}},
+				},
+				ConsenterNodes: []Node{
+					{CommonName: "consenter", Hostname: "localhost", SANS: sans},
+				},
+				OrdererNodes: []Node{
+					{CommonName: "router", Hostname: "localhost", SANS: sans},
+				},
+			},
+		},
+		ArmaMetaBytes: []byte("arma"),
+	}
+
+	profile, err := CreateOrExtendProfileWithCrypto(conf)
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+
+	// Defaults should have been applied.
+	require.Equal(t, "chan", conf.ChannelID)
+	require.NotEmpty(t, conf.BaseProfile)
+}
+
+func TestCreateOrExtendProfileWithCrypto_ExplicitChannelAndProfile(t *testing.T) {
+	// An explicit BaseProfile and ChannelID are preserved unchanged.
+	t.Parallel()
+	target := t.TempDir()
+	conf := &ConfigBlockParameters{
+		TargetPath:  target,
+		BaseProfile: "SampleFabricX",
+		ChannelID:   "explicit-chan",
+		Organizations: []OrganizationParameters{
+			{
+				Name:   ordererOrgName,
+				Domain: ordererOrgName + ".com",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					{ID: 1, Host: "localhost", Port: 7050, API: []string{types.Broadcast}},
+				},
+				ConsenterNodes: []Node{
+					{CommonName: "consenter", Hostname: "localhost", SANS: sans},
+				},
+				OrdererNodes: []Node{
+					{CommonName: "router", Hostname: "localhost", SANS: sans},
+				},
+			},
+		},
+		ArmaMetaBytes: []byte("explicit-arma"),
+	}
+
+	profile, err := CreateOrExtendProfileWithCrypto(conf)
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+	require.Equal(t, "explicit-chan", conf.ChannelID)
+	require.Equal(t, "SampleFabricX", conf.BaseProfile)
+}
+
+func TestCreateOrExtendProfileWithCrypto_InvalidBaseProfile(t *testing.T) {
+	// A non-existent profile name must return an error.
+	t.Parallel()
+	target := t.TempDir()
+	conf := &ConfigBlockParameters{
+		TargetPath:  target,
+		BaseProfile: "NonExistentProfile",
+		Organizations: []OrganizationParameters{
+			{
+				Name:   ordererOrgName,
+				Domain: ordererOrgName + ".com",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					{ID: 1, Host: "localhost", Port: 7050, API: []string{types.Broadcast}},
+				},
+				ConsenterNodes: []Node{
+					{CommonName: "consenter", Hostname: "localhost", SANS: sans},
+				},
+			},
+		},
+	}
+
+	_, err := CreateOrExtendProfileWithCrypto(conf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "NonExistentProfile")
+}
+
+func TestCreateOrExtendProfileWithCrypto_DuplicatePartyID(t *testing.T) {
+	// Two organizations that share the same party ID must be rejected.
+	t.Parallel()
+	target := t.TempDir()
+	conf := &ConfigBlockParameters{
+		TargetPath: target,
+		Organizations: []OrganizationParameters{
+			{
+				Name:   "orderer-org-a",
+				Domain: "orderer-org-a.com",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					{ID: 1, Host: "localhost", Port: 7050, API: []string{types.Broadcast}},
+				},
+				ConsenterNodes: []Node{
+					{CommonName: "consenter", Hostname: "localhost", SANS: sans},
+				},
+				OrdererNodes: []Node{
+					{CommonName: "router", Hostname: "localhost", SANS: sans},
+				},
+			},
+			{
+				Name:   "orderer-org-b",
+				Domain: "orderer-org-b.com",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					// Same party ID 1 — must trigger a duplicate error.
+					{ID: 1, Host: "localhost", Port: 7051, API: []string{types.Broadcast}},
+				},
+				ConsenterNodes: []Node{
+					{CommonName: "consenter", Hostname: "localhost", SANS: sans},
+				},
+				OrdererNodes: []Node{
+					{CommonName: "router", Hostname: "localhost", SANS: sans},
+				},
+			},
+		},
+		ArmaMetaBytes: []byte("arma"),
+	}
+
+	_, err := CreateOrExtendProfileWithCrypto(conf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate party id")
+}
+
+func TestCreateOrExtendProfileWithCrypto_OrgRouting(t *testing.T) {
+	// Verify that organizations are routed to the correct profile lists:
+	//   - orderer-only  → profile.Orderer.Organizations
+	//   - peer-only     → profile.Application.Organizations
+	//   - both          → both lists (generic)
+	t.Parallel()
+	target := t.TempDir()
+	conf := &ConfigBlockParameters{
+		TargetPath: target,
+		Organizations: []OrganizationParameters{
+			{ // orderer-only
+				Name:   ordererOrgName,
+				Domain: ordererOrgName + ".com",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					{ID: 1, Host: "localhost", Port: 7050, API: []string{types.Broadcast}},
+				},
+				ConsenterNodes: []Node{
+					{CommonName: "consenter", Hostname: "localhost", SANS: sans},
+				},
+				OrdererNodes: []Node{
+					{CommonName: "router", Hostname: "localhost", SANS: sans},
+				},
+			},
+			{ // peer-only
+				Name:      "peer-org",
+				Domain:    "peer-org.com",
+				PeerNodes: peerNodes,
+			},
+			{ // generic (both orderer and peer nodes)
+				Name:   genericOrgName,
+				Domain: genericOrgName + ".com",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					{ID: 2, Host: "localhost", Port: 7051, API: []string{types.Broadcast}},
+				},
+				ConsenterNodes: []Node{
+					{CommonName: "consenter", Hostname: "localhost", SANS: sans},
+				},
+				OrdererNodes: []Node{
+					{CommonName: "router", Hostname: "localhost", SANS: sans},
+				},
+				PeerNodes: peerNodes,
+			},
+		},
+		ArmaMetaBytes: []byte("arma"),
+	}
+
+	profile, err := CreateOrExtendProfileWithCrypto(conf)
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+
+	// orderer-org + generic-org appear in orderer organizations.
+	ordererOrgNames := make([]string, 0, len(profile.Orderer.Organizations))
+	for _, o := range profile.Orderer.Organizations {
+		ordererOrgNames = append(ordererOrgNames, o.Name)
+	}
+	require.ElementsMatch(t, []string{ordererOrgName, genericOrgName}, ordererOrgNames)
+
+	// peer-org + generic-org appear in application organizations.
+	appOrgNames := make([]string, 0, len(profile.Application.Organizations))
+	for _, o := range profile.Application.Organizations {
+		appOrgNames = append(appOrgNames, o.Name)
+	}
+	require.ElementsMatch(t, []string{"peer-org", genericOrgName}, appOrgNames)
+
+	// Consenter mapping holds one entry per ConsenterNode across all orgs.
+	require.Len(t, profile.Orderer.ConsenterMapping, 2)
+
+	// Consortiums must be cleared.
+	require.Nil(t, profile.Consortiums)
+}
+
+func TestCreateOrExtendProfileWithCrypto_ConsenterMappingFields(t *testing.T) {
+	// Verify the consenter entries have the expected host, port, and MSPID.
+	t.Parallel()
+	target := t.TempDir()
+	conf := &ConfigBlockParameters{
+		TargetPath: target,
+		Organizations: []OrganizationParameters{
+			{
+				Name:   "my-orderer-org",
+				Domain: "my-orderer-org.com",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					{ID: 7, Host: "node.example.com", Port: 5000, API: []string{types.Broadcast}},
+				},
+				ConsenterNodes: []Node{
+					{CommonName: "consenter", Hostname: "node.example.com:5000", SANS: sans},
+				},
+				OrdererNodes: []Node{
+					{CommonName: "router", Hostname: "node.example.com", SANS: sans},
+				},
+			},
+		},
+		ArmaMetaBytes: []byte("arma"),
+	}
+
+	profile, err := CreateOrExtendProfileWithCrypto(conf)
+	require.NoError(t, err)
+	require.Len(t, profile.Orderer.ConsenterMapping, 1)
+
+	c := profile.Orderer.ConsenterMapping[0]
+	require.Equal(t, uint32(7), c.ID)
+	require.Equal(t, "node.example.com", c.Host)
+	require.Equal(t, uint32(5000), c.Port)
+	require.Equal(t, "my-orderer-org", c.MSPID)
 }


### PR DESCRIPTION
<!--
Copyright IBM Corp. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0

DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST.

If this PR introduces a breaking change that affects compatibility with other components:
- The PR title must begin with the prefix [BREAKING].
- "Breaking change" must be included in the list below.
- Relevant stakeholders must be notified before or immediately after the PR is merged.
-->
#### Type of change
- improvement to code

#### Description

Update the cryptographic material generation to be compatible with the armageddon workflow

#### Additional details (Optional)

#### Related issues

https://github.com/hyperledger/fabric-x-orderer/issues/956
