### PR TITLE
Add non-standalone system transaction statuses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ TESTS*.xml
 .vagrant/
 .vscode
 .bob
+.worktrees/
 *coverage.profile

--- a/api/committerpb/status.pb.go
+++ b/api/committerpb/status.pb.go
@@ -59,6 +59,7 @@ const (
 	Status_MALFORMED_CONFIG_TX_INVALID               Status = 115 // Invalid configuration transaction.
 	Status_MALFORMED_SNAPSHOT_NOT_MARKER_ONLY        Status = 116 // _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
 	Status_MALFORMED_CHECKPOINT_INVALID_KEY          Status = 117 // _checkpoint TX read-write key does not decode as a valid TxHeight.
+	Status_MALFORMED_SYSTEM_TX_NOT_STANDALONE        Status = 118 // System TX must be standalone and cannot be mixed with other namespaces.
 )
 
 // Enum value maps for Status.
@@ -86,6 +87,7 @@ var (
 		115: "MALFORMED_CONFIG_TX_INVALID",
 		116: "MALFORMED_SNAPSHOT_NOT_MARKER_ONLY",
 		117: "MALFORMED_CHECKPOINT_INVALID_KEY",
+		118: "MALFORMED_SYSTEM_TX_NOT_STANDALONE",
 	}
 	Status_value = map[string]int32{
 		"STATUS_UNSPECIFIED":                        0,
@@ -110,6 +112,7 @@ var (
 		"MALFORMED_CONFIG_TX_INVALID":               115,
 		"MALFORMED_SNAPSHOT_NOT_MARKER_ONLY":        116,
 		"MALFORMED_CHECKPOINT_INVALID_KEY":          117,
+		"MALFORMED_SYSTEM_TX_NOT_STANDALONE":        118,
 	}
 )
 
@@ -247,7 +250,7 @@ const file_api_committerpb_status_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x03(\v2\x15.committerpb.TxStatusR\x06status\"]\n" +
 	"\bTxStatus\x12$\n" +
 	"\x03ref\x18\x01 \x01(\v2\x12.committerpb.TxRefR\x03ref\x12+\n" +
-	"\x06status\x18\x02 \x01(\x0e2\x13.committerpb.StatusR\x06status*\xd6\x05\n" +
+	"\x06status\x18\x02 \x01(\x0e2\x13.committerpb.StatusR\x06status*\xfe\x05\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tCOMMITTED\x10\x01\x12\x1d\n" +
@@ -270,7 +273,8 @@ const file_api_committerpb_status_proto_rawDesc = "" +
 	"\"MALFORMED_NAMESPACE_POLICY_INVALID\x10r\x12\x1f\n" +
 	"\x1bMALFORMED_CONFIG_TX_INVALID\x10s\x12&\n" +
 	"\"MALFORMED_SNAPSHOT_NOT_MARKER_ONLY\x10t\x12$\n" +
-	" MALFORMED_CHECKPOINT_INVALID_KEY\x10uB8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
+	" MALFORMED_CHECKPOINT_INVALID_KEY\x10u\x12&\n" +
+	"\"MALFORMED_SYSTEM_TX_NOT_STANDALONE\x10vB8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
 
 var (
 	file_api_committerpb_status_proto_rawDescOnce sync.Once

--- a/api/committerpb/status.proto
+++ b/api/committerpb/status.proto
@@ -57,4 +57,5 @@ enum Status {
     MALFORMED_CONFIG_TX_INVALID = 115;                  // Invalid configuration transaction.
     MALFORMED_SNAPSHOT_NOT_MARKER_ONLY = 116;           // _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
     MALFORMED_CHECKPOINT_INVALID_KEY = 117;             // _checkpoint TX read-write key does not decode as a valid TxHeight.
+    MALFORMED_SYSTEM_TX_NOT_STANDALONE = 118;           // System TX must be standalone and cannot be mixed with other namespaces.
 }

--- a/api/committerpb/types.go
+++ b/api/committerpb/types.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package committerpb
 
+import "slices"
+
 const (
 	// MetaNamespaceID is the system's namespace ID that holds information about application's namespaces.
 	MetaNamespaceID = "_meta"
@@ -18,6 +20,23 @@ const (
 	// ConfigKey is the key of the config transaction.
 	ConfigKey = "_config"
 )
+
+var systemNamespaces = [...]string{
+	MetaNamespaceID,
+	ConfigNamespaceID,
+	SnapshotNamespaceID,
+	CheckpointNamespaceID,
+}
+
+// SystemNamespaces returns all reserved system namespace IDs.
+func SystemNamespaces() []string {
+	return slices.Clone(systemNamespaces[:])
+}
+
+// IsSystemNamespace returns true if nsID is a reserved system namespace ID.
+func IsSystemNamespace(nsID string) bool {
+	return slices.Contains(systemNamespaces[:], nsID)
+}
 
 // NewTxRef is a convenient method to create a full TX reference in a single line.
 func NewTxRef(txID string, blockNum uint64, txNum uint32) *TxRef {

--- a/api/committerpb/types_test.go
+++ b/api/committerpb/types_test.go
@@ -26,3 +26,66 @@ func TestHeightComparison(t *testing.T) {
 	require.False(t, NewTxRef("tx1", 10, 100).IsHeight(11, 100))
 	require.False(t, NewTxRef("tx1", 10, 100).IsHeight(10, 101))
 }
+
+func TestSystemNamespaces(t *testing.T) {
+	t.Parallel()
+
+	namespaces := SystemNamespaces()
+	require.Equal(t, []string{
+		MetaNamespaceID,
+		ConfigNamespaceID,
+		SnapshotNamespaceID,
+		CheckpointNamespaceID,
+	}, namespaces)
+
+	namespaces[0] = "mutated"
+	require.Equal(t, MetaNamespaceID, SystemNamespaces()[0])
+}
+
+func TestIsSystemNamespace(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		description string
+		nsID        string
+		expected    bool
+	}{
+		{
+			description: "meta namespace",
+			nsID:        MetaNamespaceID,
+			expected:    true,
+		},
+		{
+			description: "config namespace",
+			nsID:        ConfigNamespaceID,
+			expected:    true,
+		},
+		{
+			description: "snapshot namespace",
+			nsID:        SnapshotNamespaceID,
+			expected:    true,
+		},
+		{
+			description: "checkpoint namespace",
+			nsID:        CheckpointNamespaceID,
+			expected:    true,
+		},
+		{
+			description: "application namespace",
+			nsID:        "asset",
+			expected:    false,
+		},
+		{
+			description: "empty namespace",
+			nsID:        "",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, IsSystemNamespace(tc.nsID))
+		})
+	}
+}


### PR DESCRIPTION
#### Type of change

 - New Feature
#### Description
- add malformed `_snapshot` and `_checkpoint` transaction statuses
- expose `committerpb.SystemNamespaces()` for safe reserved namespace iteration
- expose `committerpb.IsSystemNamespace(string)` so downstream repos can remove duplicated predicates

#### Additional details (Optional)

#### Related issues

 - resolves #141
