### PR TITLE
[committerpb] Add snapshot rejection status codes

### DIFF
--- a/api/committerpb/status.pb.go
+++ b/api/committerpb/status.pb.go
@@ -26,9 +26,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Status represents the result of transaction validation.
-// Except for STATUS_UNSPECIFIED, all statuses are recorded in the ledger.
-// Some statuses are also stored in the state database which prevent resubmission of the same transaction ID.
 type Status int32
 
 const (
@@ -60,6 +57,9 @@ const (
 	Status_MALFORMED_SNAPSHOT_NOT_MARKER_ONLY        Status = 116 // _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
 	Status_MALFORMED_CHECKPOINT_INVALID_KEY          Status = 117 // _checkpoint TX read-write key does not decode as a valid TxHeight.
 	Status_MALFORMED_SYSTEM_TX_NOT_STANDALONE        Status = 118 // System TX must be standalone and cannot be mixed with other namespaces.
+	Status_REJECTED_SNAPSHOT_IN_PROGRESS             Status = 119 // Another snapshot is still being hashed / awaiting its checkpoint (a prior _snapshot row is not yet CHECKPOINTED).
+	Status_REJECTED_SNAPSHOT_NO_CHECKPOINT           Status = 120 // A prior snapshot exists that was never checkpointed, so a new snapshot cannot be accepted.
+	Status_REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK      Status = 121 // More than one snapshot TX appeared in the same block; only the first is processed and the rest are rejected regardless of the first's outcome.
 )
 
 // Enum value maps for Status.
@@ -88,6 +88,9 @@ var (
 		116: "MALFORMED_SNAPSHOT_NOT_MARKER_ONLY",
 		117: "MALFORMED_CHECKPOINT_INVALID_KEY",
 		118: "MALFORMED_SYSTEM_TX_NOT_STANDALONE",
+		119: "REJECTED_SNAPSHOT_IN_PROGRESS",
+		120: "REJECTED_SNAPSHOT_NO_CHECKPOINT",
+		121: "REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK",
 	}
 	Status_value = map[string]int32{
 		"STATUS_UNSPECIFIED":                        0,
@@ -113,6 +116,9 @@ var (
 		"MALFORMED_SNAPSHOT_NOT_MARKER_ONLY":        116,
 		"MALFORMED_CHECKPOINT_INVALID_KEY":          117,
 		"MALFORMED_SYSTEM_TX_NOT_STANDALONE":        118,
+		"REJECTED_SNAPSHOT_IN_PROGRESS":             119,
+		"REJECTED_SNAPSHOT_NO_CHECKPOINT":           120,
+		"REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK":      121,
 	}
 )
 
@@ -250,7 +256,7 @@ const file_api_committerpb_status_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x03(\v2\x15.committerpb.TxStatusR\x06status\"]\n" +
 	"\bTxStatus\x12$\n" +
 	"\x03ref\x18\x01 \x01(\v2\x12.committerpb.TxRefR\x03ref\x12+\n" +
-	"\x06status\x18\x02 \x01(\x0e2\x13.committerpb.StatusR\x06status*\xfe\x05\n" +
+	"\x06status\x18\x02 \x01(\x0e2\x13.committerpb.StatusR\x06status*\xf0\x06\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tCOMMITTED\x10\x01\x12\x1d\n" +
@@ -274,7 +280,10 @@ const file_api_committerpb_status_proto_rawDesc = "" +
 	"\x1bMALFORMED_CONFIG_TX_INVALID\x10s\x12&\n" +
 	"\"MALFORMED_SNAPSHOT_NOT_MARKER_ONLY\x10t\x12$\n" +
 	" MALFORMED_CHECKPOINT_INVALID_KEY\x10u\x12&\n" +
-	"\"MALFORMED_SYSTEM_TX_NOT_STANDALONE\x10vB8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
+	"\"MALFORMED_SYSTEM_TX_NOT_STANDALONE\x10v\x12!\n" +
+	"\x1dREJECTED_SNAPSHOT_IN_PROGRESS\x10w\x12#\n" +
+	"\x1fREJECTED_SNAPSHOT_NO_CHECKPOINT\x10x\x12(\n" +
+	"$REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK\x10yB8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
 
 var (
 	file_api_committerpb_status_proto_rawDescOnce sync.Once

--- a/api/committerpb/status.proto
+++ b/api/committerpb/status.proto
@@ -1,61 +1,61 @@
 /*
-Copyright IBM Corp. All Rights Reserved.
+   Copyright IBM Corp. All Rights Reserved.
 
-SPDX-License-Identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
 */
 
 syntax = "proto3";
-
-option go_package = "github.com/hyperledger/fabric-x-common/api/committerpb";
 
 package committerpb;
 
 import "api/committerpb/ref.proto";
 
+option go_package = "github.com/hyperledger/fabric-x-common/api/committerpb";
+
 // A batch of TXs' status.
 message TxStatusBatch {
-    repeated TxStatus status = 1;
+  repeated TxStatus status = 1;
 }
 
 // The status of a TX.
 message TxStatus {
-    TxRef ref = 1;
-    Status status = 2;
+  TxRef ref = 1;
+  Status status = 2;
 }
 
-// Status represents the result of transaction validation.
-// Except for STATUS_UNSPECIFIED, all statuses are recorded in the ledger.
-// Some statuses are also stored in the state database which prevent resubmission of the same transaction ID.
 enum Status {
-    // Should never be persisted or reported.
-    STATUS_UNSPECIFIED = 0;                             // Default. The transaction has not been validated yet.
+  // Should never be persisted or reported.
+  STATUS_UNSPECIFIED = 0; // Default. The transaction has not been validated yet.
 
-    // Stored in the state database. Prevents submitting a transaction with the same ID.
-    COMMITTED = 1;                                      // Successfully committed and state updated.
-    ABORTED_SIGNATURE_INVALID = 2;                      // Signature is invalid according to the namespace policy.
-    ABORTED_MVCC_CONFLICT = 3;                          // Read-write set conflict.
+  // Stored in the state database. Prevents submitting a transaction with the same ID.
+  COMMITTED = 1; // Successfully committed and state updated.
+  ABORTED_SIGNATURE_INVALID = 2; // Signature is invalid according to the namespace policy.
+  ABORTED_MVCC_CONFLICT = 3; // Read-write set conflict.
 
-    // Cannot be stored in the state database because the TX ID cannot be extracted,
-    // or the TX ID entry is already occupied.
-    REJECTED_DUPLICATE_TX_ID = 100;                     // Transaction with the same ID has already been processed.
-    MALFORMED_BAD_ENVELOPE = 101;                       // Cannot unmarshal envelope.
-    MALFORMED_MISSING_TX_ID = 102;                      // Envelope is missing transaction ID.
+  // Cannot be stored in the state database because the TX ID cannot be extracted,
+  // or the TX ID entry is already occupied.
+  REJECTED_DUPLICATE_TX_ID = 100; // Transaction with the same ID has already been processed.
+  MALFORMED_BAD_ENVELOPE = 101; // Cannot unmarshal envelope.
+  MALFORMED_MISSING_TX_ID = 102; // Envelope is missing transaction ID.
 
-    // Stored in the state database. Prevents submitting a transaction with the same ID.
-    MALFORMED_UNSUPPORTED_ENVELOPE_PAYLOAD = 103;       // Unsupported envelope payload type.
-    MALFORMED_BAD_ENVELOPE_PAYLOAD = 104;               // Cannot unmarshal envelope's payload.
-    MALFORMED_TX_ID_CONFLICT = 105;                     // Envelope's TX ID does not match the payload's TX ID.
-    MALFORMED_EMPTY_NAMESPACES = 106;                   // No namespaces provided.
-    MALFORMED_DUPLICATE_NAMESPACE = 107;                // Duplicate namespace detected.
-    MALFORMED_NAMESPACE_ID_INVALID = 108;               // Invalid namespace identifier.
-    MALFORMED_BLIND_WRITES_NOT_ALLOWED = 109;           // Blind writes are not allowed in a namespace transaction.
-    MALFORMED_NO_WRITES = 110;                          // No write operations in the transaction.
-    MALFORMED_EMPTY_KEY = 111;                          // Unset key detected.
-    MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET = 112;    // Duplicate key in the read-write set.
-    MALFORMED_MISSING_SIGNATURE = 113;                  // Number of signatures does not match the number of namespaces.
-    MALFORMED_NAMESPACE_POLICY_INVALID = 114;           // Invalid namespace policy.
-    MALFORMED_CONFIG_TX_INVALID = 115;                  // Invalid configuration transaction.
-    MALFORMED_SNAPSHOT_NOT_MARKER_ONLY = 116;           // _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
-    MALFORMED_CHECKPOINT_INVALID_KEY = 117;             // _checkpoint TX read-write key does not decode as a valid TxHeight.
-    MALFORMED_SYSTEM_TX_NOT_STANDALONE = 118;           // System TX must be standalone and cannot be mixed with other namespaces.
+  // Stored in the state database. Prevents submitting a transaction with the same ID.
+  MALFORMED_UNSUPPORTED_ENVELOPE_PAYLOAD = 103; // Unsupported envelope payload type.
+  MALFORMED_BAD_ENVELOPE_PAYLOAD = 104; // Cannot unmarshal envelope's payload.
+  MALFORMED_TX_ID_CONFLICT = 105; // Envelope's TX ID does not match the payload's TX ID.
+  MALFORMED_EMPTY_NAMESPACES = 106; // No namespaces provided.
+  MALFORMED_DUPLICATE_NAMESPACE = 107; // Duplicate namespace detected.
+  MALFORMED_NAMESPACE_ID_INVALID = 108; // Invalid namespace identifier.
+  MALFORMED_BLIND_WRITES_NOT_ALLOWED = 109; // Blind writes are not allowed in a namespace transaction.
+  MALFORMED_NO_WRITES = 110; // No write operations in the transaction.
+  MALFORMED_EMPTY_KEY = 111; // Unset key detected.
+  MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET = 112; // Duplicate key in the read-write set.
+  MALFORMED_MISSING_SIGNATURE = 113; // Number of signatures does not match the number of namespaces.
+  MALFORMED_NAMESPACE_POLICY_INVALID = 114; // Invalid namespace policy.
+  MALFORMED_CONFIG_TX_INVALID = 115; // Invalid configuration transaction.
+  MALFORMED_SNAPSHOT_NOT_MARKER_ONLY = 116; // _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
+  MALFORMED_CHECKPOINT_INVALID_KEY = 117; // _checkpoint TX read-write key does not decode as a valid TxHeight.
+  MALFORMED_SYSTEM_TX_NOT_STANDALONE = 118; // System TX must be standalone and cannot be mixed with other namespaces.
+  REJECTED_SNAPSHOT_IN_PROGRESS = 119; // Another snapshot is still being hashed / awaiting its checkpoint (a prior _snapshot row is not yet CHECKPOINTED).
+  REJECTED_SNAPSHOT_NO_CHECKPOINT = 120; // A prior snapshot exists that was never checkpointed, so a new snapshot cannot be accepted.
+  REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK = 121; // More than one snapshot TX appeared in the same block; only the first is processed and the rest are rejected regardless of the first's outcome.
 }


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Add three REJECTED_* status codes for snapshot transaction validation:

- REJECTED_SNAPSHOT_IN_PROGRESS (119): a prior committed snapshot is not yet CHECKPOINTED, so a new snapshot cannot be accepted.
- REJECTED_SNAPSHOT_NO_CHECKPOINT (120): a prior snapshot exists that was never checkpointed.
- REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK (121): more than one snapshot TX appeared in the same block; only the first is processed and the rest are rejected regardless of the first's outcome.

#### Additional details (Optional)

All three are well-formed transactions with a valid, extractable TX ID, so they are placed in the stored band (like ABORTED_MVCC_CONFLICT): the outcome is recorded in the state database. Storing does not block legitimate retries, which always use a fresh TX ID.

#### Related issues

<!--- Include a link to any associated Github issue -->
