### PR TITLE
Add snapshot rejection status codes

### DIFF
--- a/api/committerpb/status.pb.go
+++ b/api/committerpb/status.pb.go
@@ -60,6 +60,9 @@ const (
 	Status_MALFORMED_SNAPSHOT_NOT_MARKER_ONLY        Status = 116 // _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
 	Status_MALFORMED_CHECKPOINT_INVALID_KEY          Status = 117 // _checkpoint TX read-write key does not decode as a valid TxHeight.
 	Status_MALFORMED_SYSTEM_TX_NOT_STANDALONE        Status = 118 // System TX must be standalone and cannot be mixed with other namespaces.
+	Status_REJECTED_SNAPSHOT_IN_PROGRESS             Status = 119 // Another snapshot is still being hashed / awaiting its checkpoint (a prior _snapshot row is not yet CHECKPOINTED).
+	Status_REJECTED_SNAPSHOT_NO_CHECKPOINT           Status = 120 // A prior snapshot exists that was never checkpointed, so a new snapshot cannot be accepted.
+	Status_REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK      Status = 121 // More than one snapshot TX appeared in the same block; only the first is processed and the rest are rejected regardless of the first's outcome.
 )
 
 // Enum value maps for Status.
@@ -88,6 +91,9 @@ var (
 		116: "MALFORMED_SNAPSHOT_NOT_MARKER_ONLY",
 		117: "MALFORMED_CHECKPOINT_INVALID_KEY",
 		118: "MALFORMED_SYSTEM_TX_NOT_STANDALONE",
+		119: "REJECTED_SNAPSHOT_IN_PROGRESS",
+		120: "REJECTED_SNAPSHOT_NO_CHECKPOINT",
+		121: "REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK",
 	}
 	Status_value = map[string]int32{
 		"STATUS_UNSPECIFIED":                        0,
@@ -113,6 +119,9 @@ var (
 		"MALFORMED_SNAPSHOT_NOT_MARKER_ONLY":        116,
 		"MALFORMED_CHECKPOINT_INVALID_KEY":          117,
 		"MALFORMED_SYSTEM_TX_NOT_STANDALONE":        118,
+		"REJECTED_SNAPSHOT_IN_PROGRESS":             119,
+		"REJECTED_SNAPSHOT_NO_CHECKPOINT":           120,
+		"REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK":      121,
 	}
 )
 
@@ -250,7 +259,7 @@ const file_api_committerpb_status_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x03(\v2\x15.committerpb.TxStatusR\x06status\"]\n" +
 	"\bTxStatus\x12$\n" +
 	"\x03ref\x18\x01 \x01(\v2\x12.committerpb.TxRefR\x03ref\x12+\n" +
-	"\x06status\x18\x02 \x01(\x0e2\x13.committerpb.StatusR\x06status*\xfe\x05\n" +
+	"\x06status\x18\x02 \x01(\x0e2\x13.committerpb.StatusR\x06status*\xf0\x06\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tCOMMITTED\x10\x01\x12\x1d\n" +
@@ -274,7 +283,10 @@ const file_api_committerpb_status_proto_rawDesc = "" +
 	"\x1bMALFORMED_CONFIG_TX_INVALID\x10s\x12&\n" +
 	"\"MALFORMED_SNAPSHOT_NOT_MARKER_ONLY\x10t\x12$\n" +
 	" MALFORMED_CHECKPOINT_INVALID_KEY\x10u\x12&\n" +
-	"\"MALFORMED_SYSTEM_TX_NOT_STANDALONE\x10vB8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
+	"\"MALFORMED_SYSTEM_TX_NOT_STANDALONE\x10v\x12!\n" +
+	"\x1dREJECTED_SNAPSHOT_IN_PROGRESS\x10w\x12#\n" +
+	"\x1fREJECTED_SNAPSHOT_NO_CHECKPOINT\x10x\x12(\n" +
+	"$REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK\x10yB8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
 
 var (
 	file_api_committerpb_status_proto_rawDescOnce sync.Once

--- a/api/committerpb/status.proto
+++ b/api/committerpb/status.proto
@@ -58,4 +58,7 @@ enum Status {
     MALFORMED_SNAPSHOT_NOT_MARKER_ONLY = 116;           // _snapshot TX has a non-empty read-write set; only a marker-only _snapshot (entirely empty read-write set) is valid.
     MALFORMED_CHECKPOINT_INVALID_KEY = 117;             // _checkpoint TX read-write key does not decode as a valid TxHeight.
     MALFORMED_SYSTEM_TX_NOT_STANDALONE = 118;           // System TX must be standalone and cannot be mixed with other namespaces.
+    REJECTED_SNAPSHOT_IN_PROGRESS = 119;                // Another snapshot is still being hashed / awaiting its checkpoint (a prior _snapshot row is not yet CHECKPOINTED).
+    REJECTED_SNAPSHOT_NO_CHECKPOINT = 120;              // A prior snapshot exists that was never checkpointed, so a new snapshot cannot be accepted.
+    REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK = 121;         // More than one snapshot TX appeared in the same block; only the first is processed and the rest are rejected regardless of the first's outcome.
 }


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Add three REJECTED_* status codes for snapshot transaction validation:

- REJECTED_SNAPSHOT_IN_PROGRESS (119): a prior committed snapshot is not yet CHECKPOINTED, so a new snapshot cannot be accepted.
- REJECTED_SNAPSHOT_NO_CHECKPOINT (120): a prior snapshot exists that was never checkpointed.
- REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK (121): more than one snapshot TX appeared in the same block; only the first is processed and the rest are rejected regardless of the first's outcome.


#### Additional details (Optional)

All three are well-formed transactions with a valid, extractable TX ID, so they are placed in the stored band (like ABORTED_MVCC_CONFLICT): the outcome is recorded in the state database. Storing does not block legitimate retries, which always use a fresh TX ID.

Regenerated status.pb.go via make proto.

#### Related issues

  - resolves #143 
