### PR TITLE
Added `toString()` and `toDisplayString()` functions to render MSP policy as string

### DIFF
--- a/common/policydsl/policyrenderer.go
+++ b/common/policydsl/policyrenderer.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package policydsl
 
 import (
-	"encoding/hex"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -16,19 +16,21 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// renderMode selects how ToString and ToDisplayString handle a construct that has no DSL
-// representation: strictMode fails the render, lenientMode substitutes a placeholder.
-type renderMode int
+// principalPlaceholderLen bounds how many bytes of a principal are encoded into a placeholder:
+// an IDENTITY principal carries a full certificate, so dumping it untruncated would put a
+// couple of KB into the rendered string.
+const principalPlaceholderLen = 8
 
+// Gate*Display are the canonical, human-readable gate spellings used by ToString and
+// ToDisplayString. They deliberately do not reuse GateAnd/GateOr/GateOutOf, which are the
+// lowercase parser tokens ("and"/"or"/"outof") rather than the display spelling; Visit
+// lowercases gate identifiers during AST traversal, so this casing still round-trips through
+// FromString.
 const (
-	strictMode renderMode = iota
-	lenientMode
+	GateAndDisplay   = "AND"
+	GateOrDisplay    = "OR"
+	GateOutOfDisplay = "OutOf"
 )
-
-// principalPlaceholderHexLen bounds how many bytes of a principal are hex-dumped into a
-// placeholder: an IDENTITY principal carries a full certificate, so dumping it untruncated
-// would put a couple of KB of hex into the rendered string.
-const principalPlaceholderHexLen = 8
 
 // ToString renders an envelope as a policy DSL expression accepted by FromString. It returns
 // an error if any part of the policy has no DSL representation.
@@ -36,39 +38,39 @@ const principalPlaceholderHexLen = 8
 // Example: the envelope produced by FromString("OR('Org1MSP.member', 'Org2MSP.member')")
 // renders back to "OR('Org1MSP.member', 'Org2MSP.member')".
 func ToString(env *cb.SignaturePolicyEnvelope) (string, error) {
-	return renderRule(env.GetRule(), env.GetIdentities(), strictMode)
+	return renderRule(env.GetRule(), env.GetIdentities())
 }
 
 // ToDisplayString renders an envelope for human consumption, substituting readable
-// placeholders for anything with no DSL representation. It never fails.
+// placeholders for anything with no DSL representation. It never fails: renderRule always
+// computes the display text, even when it also returns a "not parsable" error, and
+// ToDisplayString simply discards that error.
 //
 // Example: an envelope built with Envelope(SignedBy(0), [][]byte{identityBytes}) — a single
 // IDENTITY principal, which has no DSL syntax — renders to "<identity:0>" instead of erroring.
 func ToDisplayString(env *cb.SignaturePolicyEnvelope) string {
-	rendered, err := renderRule(env.GetRule(), env.GetIdentities(), lenientMode)
-	if err != nil {
-		// renderRule never errors in lenientMode; this is unreachable.
-		return err.Error()
-	}
+	rendered, _ := renderRule(env.GetRule(), env.GetIdentities())
 	return rendered
 }
 
 // renderRule renders a single SignaturePolicy node, dispatching on its oneof type: an NOutOf
 // node (e.g. NOutOf{N: 1, Rules: [SignedBy(0), SignedBy(1)]}) renders via renderNOutOf (e.g.
 // to "OR('Org1MSP.member', 'Org2MSP.member')"), a SignedBy node (e.g. SignedBy(0)) renders via
-// renderSignedBy (e.g. to "'Org1MSP.member'"), and anything else (there is no third oneof case
-// today) renders as "<unknown-rule>" in lenientMode or errors in strictMode.
-func renderRule(rule *cb.SignaturePolicy, identities []*mb.MSPPrincipal, mode renderMode) (string, error) {
+// renderSignedBy (e.g. to "'Org1MSP.member'"), and anything else — including a rule with no
+// oneof case set at all, e.g. &cb.SignaturePolicy{} — renders as "<unknown-rule>" alongside an
+// error, since neither today's two oneof cases nor a future third one is guaranteed.
+//
+// The returned string is always the fully rendered display text; the returned error, when
+// non-nil, means that text has no DSL representation (it would not round-trip through
+// FromString). ToString propagates the error; ToDisplayString discards it.
+func renderRule(rule *cb.SignaturePolicy, identities []*mb.MSPPrincipal) (string, error) {
 	switch t := rule.GetType().(type) {
 	case *cb.SignaturePolicy_NOutOf_:
-		return renderNOutOf(t.NOutOf, identities, mode)
+		return renderNOutOf(t.NOutOf, identities)
 	case *cb.SignaturePolicy_SignedBy:
-		return renderSignedBy(t.SignedBy, identities, mode)
+		return renderSignedBy(t.SignedBy, identities)
 	default:
-		if mode == strictMode {
-			return "", fmt.Errorf("policy rule has no DSL representation: %T", t)
-		}
-		return "<unknown-rule>", nil
+		return "<unknown-rule>", fmt.Errorf("policy rule has no DSL representation: %T", t)
 	}
 }
 
@@ -86,119 +88,106 @@ func renderRule(rule *cb.SignaturePolicy, identities []*mb.MSPPrincipal, mode re
 // NOutOf{N: 1, Rules: []} (RejectAllPolicy), has no DSL representation: FromString's nOutOf
 // rejects any OutOf/And/Or call with fewer than one policy argument (policyparser.go's
 // "expected at least two arguments to NOutOf"), so there is no string of the form "OutOf(N)"
-// that actually parses back to it, even though it renders as exactly that in lenientMode.
-// strictMode errors instead of emitting text FromString would reject.
-func renderNOutOf(nOutOf *cb.SignaturePolicy_NOutOf, identities []*mb.MSPPrincipal, mode renderMode) (string, error) {
+// that actually parses back to it, even though that is exactly the text rendered here. The
+// returned error reflects that; ToDisplayString discards it and keeps the text.
+func renderNOutOf(nOutOf *cb.SignaturePolicy_NOutOf, identities []*mb.MSPPrincipal) (string, error) {
 	n := nOutOf.GetN()
 	rules := nOutOf.GetRules()
 
 	if len(rules) == 0 {
-		if mode == strictMode {
-			return "", fmt.Errorf("NOutOf with no rules (n=%d) has no DSL representation", n)
-		}
-		return fmt.Sprintf("%s(%d)", GateOutOfDisplay, n), nil
+		return fmt.Sprintf("%s(%d)", GateOutOfDisplay, n),
+			fmt.Errorf("NOutOf with no rules (n=%d) has no DSL representation", n)
 	}
 
-	rendered, err := renderAll(rules, identities, mode)
-	if err != nil {
-		return "", err
-	}
+	rendered, err := renderAll(rules, identities)
 
-	switch {
-	case n == 1:
-		return fmt.Sprintf("%s(%s)", GateOrDisplay, strings.Join(rendered, ", ")), nil
-	case int(n) == len(rules):
-		return fmt.Sprintf("%s(%s)", GateAndDisplay, strings.Join(rendered, ", ")), nil
+	switch int(n) {
+	case 1:
+		return fmt.Sprintf("%s(%s)", GateOrDisplay, strings.Join(rendered, ", ")), err
+	case len(rules):
+		return fmt.Sprintf("%s(%s)", GateAndDisplay, strings.Join(rendered, ", ")), err
 	default:
-		return fmt.Sprintf("%s(%d, %s)", GateOutOfDisplay, n, strings.Join(rendered, ", ")), nil
+		return fmt.Sprintf("%s(%d, %s)", GateOutOfDisplay, n, strings.Join(rendered, ", ")), err
 	}
 }
 
 // renderAll renders each rule in rules independently and returns the rendered strings in the
 // same order, e.g. [SignedBy(0), SignedBy(1)] -> []string{"'Org1MSP.member'", "'Org2MSP.member'"}.
-// It stops at the first error, so a single unrenderable rule fails the whole slice in strictMode.
-func renderAll(rules []*cb.SignaturePolicy, identities []*mb.MSPPrincipal, mode renderMode) ([]string, error) {
+// Every rule is rendered regardless of errors, so the returned text is always complete even when
+// a sub-rule has no DSL representation; the first such error encountered, if any, is returned
+// alongside the full text.
+func renderAll(rules []*cb.SignaturePolicy, identities []*mb.MSPPrincipal) ([]string, error) {
 	rendered := make([]string, len(rules))
+	var firstErr error
 	for i, rule := range rules {
-		r, err := renderRule(rule, identities, mode)
-		if err != nil {
-			return nil, err
-		}
+		r, err := renderRule(rule, identities)
 		rendered[i] = r
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
-	return rendered, nil
+	return rendered, firstErr
 }
 
 // renderSignedBy resolves a SignedBy index into the corresponding identities entry and renders
 // that principal, e.g. SignedBy(0) against identities[0] = {MspIdentifier: "Org1MSP",
 // Role: MEMBER} -> "'Org1MSP.member'". An index outside the identities slice (a malformed
-// envelope) renders as "<principal[N]>" in lenientMode or errors in strictMode.
-func renderSignedBy(index int32, identities []*mb.MSPPrincipal, mode renderMode) (string, error) {
+// envelope) renders as "<principal[N]>" alongside an error.
+func renderSignedBy(index int32, identities []*mb.MSPPrincipal) (string, error) {
 	if index < 0 || int(index) >= len(identities) {
-		if mode == strictMode {
-			return "", fmt.Errorf("signed_by index %d out of range of %d identities", index, len(identities))
-		}
-		return fmt.Sprintf("<principal[%d]>", index), nil
+		return fmt.Sprintf("<principal[%d]>", index),
+			fmt.Errorf("signed_by index %d out of range of %d identities", index, len(identities))
 	}
-	return renderPrincipal(identities[index], index, mode)
+	return renderPrincipal(identities[index], index)
 }
 
 // renderPrincipal renders an MSPPrincipal, dispatching on its PrincipalClassification:
 //   - ROLE, e.g. {MspIdentifier: "Org1MSP", Role: MEMBER} -> "'Org1MSP.member'" (renderRolePrincipal)
 //   - ORGANIZATION_UNIT, e.g. {MspIdentifier: "Org1MSP", OrganizationalUnitIdentifier: "eng"}
-//     -> "'Org1MSP.eng'" in lenientMode (renderOUPrincipal) or an error in strictMode: unlike
-//     ROLE, FromString's roleRegex only matches the five MSP role suffixes, so there is no DSL
-//     syntax for an organization unit at all, in any spelling, even though the rendered text is
-//     shaped exactly like a valid ROLE principal
+//     -> "'Org1MSP.eng'" alongside an error (renderOUPrincipal): unlike ROLE, FromString's
+//     roleRegex only matches the five MSP role suffixes, so there is no DSL syntax for an
+//     organization unit at all, in any spelling, even though the rendered text is shaped
+//     exactly like a valid ROLE principal
 //   - IDENTITY, which carries a full serialized identity with no DSL syntax -> "<identity:N>"
-//     in lenientMode (N is the identities index) or an error in strictMode
-//   - ANONYMITY / COMBINED (no DSL syntax either) -> "<principal:a1b2c3d4>" in lenientMode
-//     (hex-truncated raw bytes) or an error in strictMode
-func renderPrincipal(principal *mb.MSPPrincipal, index int32, mode renderMode) (string, error) {
+//     alongside an error (N is the identities index)
+//   - ANONYMITY / COMBINED (no DSL syntax either) -> "<principal:...>" alongside an error
+//     (a length-bounded encoding of the raw bytes)
+func renderPrincipal(principal *mb.MSPPrincipal, index int32) (string, error) {
 	switch principal.GetPrincipalClassification() {
 	case mb.MSPPrincipal_ROLE:
-		return renderRolePrincipal(principal, mode)
+		return renderRolePrincipal(principal)
 	case mb.MSPPrincipal_ORGANIZATION_UNIT:
-		if mode == strictMode {
-			return "", fmt.Errorf("organization_unit principal at index %d has no DSL representation", index)
-		}
-		return renderOUPrincipal(principal), nil
+		return renderOUPrincipal(principal),
+			fmt.Errorf("organization_unit principal at index %d has no DSL representation", index)
 	case mb.MSPPrincipal_IDENTITY:
-		if mode == strictMode {
-			return "", fmt.Errorf("identity principal at index %d has no DSL representation", index)
-		}
-		return fmt.Sprintf("<identity:%d>", index), nil
+		return fmt.Sprintf("<identity:%d>", index),
+			fmt.Errorf("identity principal at index %d has no DSL representation", index)
 	default:
-		if mode == strictMode {
-			return "", fmt.Errorf(
-				"principal classification %s has no DSL representation", principal.GetPrincipalClassification(),
-			)
-		}
-		return placeholderPrincipal(principal.GetPrincipal()), nil
+		return placeholderPrincipal(principal.GetPrincipal()), fmt.Errorf(
+			"principal classification %s has no DSL representation", principal.GetPrincipalClassification(),
+		)
 	}
 }
 
 // renderRolePrincipal unmarshals a ROLE principal's bytes into an MSPRole and renders it as
 // 'mspID.role', lowercasing the role, e.g. MSPRole{MspIdentifier: "Org1MSP", Role: ADMIN} ->
 // "'Org1MSP.admin'". Bytes that fail to unmarshal (corrupt data, not a client bug) render as
-// a hex placeholder in lenientMode or error in strictMode.
-func renderRolePrincipal(principal *mb.MSPPrincipal, mode renderMode) (string, error) {
+// a placeholder alongside an error.
+func renderRolePrincipal(principal *mb.MSPPrincipal) (string, error) {
 	role := &mb.MSPRole{}
 	if err := proto.Unmarshal(principal.GetPrincipal(), role); err != nil {
-		if mode == strictMode {
-			return "", fmt.Errorf("could not unmarshal MSPRole: %w", err)
-		}
-		return placeholderPrincipal(principal.GetPrincipal()), nil
+		return placeholderPrincipal(principal.GetPrincipal()), fmt.Errorf("could not unmarshal MSPRole: %w", err)
 	}
 	return fmt.Sprintf("'%s.%s'", role.GetMspIdentifier(), strings.ToLower(role.GetRole().String())), nil
 }
 
 // renderOUPrincipal unmarshals an ORGANIZATION_UNIT principal's bytes into an OrganizationUnit
 // and renders it as 'mspID.ouID', e.g. OrganizationUnit{MspIdentifier: "Org1MSP",
-// OrganizationalUnitIdentifier: "engineering"} -> "'Org1MSP.engineering'". Only called from
-// renderPrincipal's lenientMode branch — ORGANIZATION_UNIT has no DSL representation at all, so
-// this text is display-only and never valid DSL, despite looking exactly like a ROLE principal.
-// Bytes that fail to unmarshal (corrupt data, not a client bug) render as a hex placeholder.
+// OrganizationalUnitIdentifier: "engineering"} -> "'Org1MSP.engineering'". Called from
+// renderPrincipal, which always pairs this text with an error — ORGANIZATION_UNIT has no DSL
+// representation at all, so this text is display-only and never valid DSL, despite looking
+// exactly like a ROLE principal. Bytes that fail to unmarshal (corrupt data, not a client bug)
+// render as a placeholder instead.
 func renderOUPrincipal(principal *mb.MSPPrincipal) string {
 	ou := &mb.OrganizationUnit{}
 	if err := proto.Unmarshal(principal.GetPrincipal(), ou); err != nil {
@@ -207,22 +196,11 @@ func renderOUPrincipal(principal *mb.MSPPrincipal) string {
 	return fmt.Sprintf("'%s.%s'", ou.GetMspIdentifier(), ou.GetOrganizationalUnitIdentifier())
 }
 
-// placeholderPrincipal renders raw principal bytes as a hex placeholder, truncated to
-// principalPlaceholderHexLen bytes, e.g. []byte("not an MSPRole") -> "<principal:6e6f7420616e204d>".
+// placeholderPrincipal renders raw principal bytes as a base64 placeholder, truncated to
+// principalPlaceholderLen bytes, e.g. []byte("not an MSPRole") -> "<principal:bm90IGFuIE0=>".
 // Truncation matters for IDENTITY principals, which carry a full certificate: dumping it
-// untruncated would put a couple of KB of hex into the rendered string.
+// untruncated would put a couple of KB into the rendered string.
 func placeholderPrincipal(raw []byte) string {
-	n := min(len(raw), principalPlaceholderHexLen)
-	return "<principal:" + hex.EncodeToString(raw[:n]) + ">"
+	n := min(len(raw), principalPlaceholderLen)
+	return "<principal:" + base64.StdEncoding.EncodeToString(raw[:n]) + ">"
 }
-
-// Gate*Display are the canonical, human-readable gate spellings used by ToString and
-// ToDisplayString. They deliberately do not reuse GateAnd/GateOr/GateOutOf, which are the
-// lowercase parser tokens ("and"/"or"/"outof") rather than the display spelling; Visit
-// lowercases gate identifiers during AST traversal, so this casing still round-trips through
-// FromString.
-const (
-	GateAndDisplay   = "AND"
-	GateOrDisplay    = "OR"
-	GateOutOfDisplay = "OutOf"
-)

--- a/common/policydsl/policyrenderer.go
+++ b/common/policydsl/policyrenderer.go
@@ -1,0 +1,214 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package policydsl
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	mb "github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"google.golang.org/protobuf/proto"
+)
+
+// renderMode selects how ToString and ToDisplayString handle a construct that has no DSL
+// representation: strictMode fails the render, lenientMode substitutes a placeholder.
+type renderMode int
+
+const (
+	strictMode renderMode = iota
+	lenientMode
+)
+
+// principalPlaceholderHexLen bounds how many bytes of a principal are hex-dumped into a
+// placeholder: an IDENTITY principal carries a full certificate, so dumping it untruncated
+// would put a couple of KB of hex into the rendered string.
+const principalPlaceholderHexLen = 8
+
+// ToString renders an envelope as a policy DSL expression accepted by FromString. It returns
+// an error if any part of the policy has no DSL representation.
+//
+// Example: the envelope produced by FromString("OR('Org1MSP.member', 'Org2MSP.member')")
+// renders back to "OR('Org1MSP.member', 'Org2MSP.member')".
+func ToString(env *cb.SignaturePolicyEnvelope) (string, error) {
+	return renderRule(env.GetRule(), env.GetIdentities(), strictMode)
+}
+
+// ToDisplayString renders an envelope for human consumption, substituting readable
+// placeholders for anything with no DSL representation. It never fails.
+//
+// Example: an envelope built with Envelope(SignedBy(0), [][]byte{identityBytes}) — a single
+// IDENTITY principal, which has no DSL syntax — renders to "<identity:0>" instead of erroring.
+func ToDisplayString(env *cb.SignaturePolicyEnvelope) string {
+	rendered, err := renderRule(env.GetRule(), env.GetIdentities(), lenientMode)
+	if err != nil {
+		// renderRule never errors in lenientMode; this is unreachable.
+		return err.Error()
+	}
+	return rendered
+}
+
+// renderRule renders a single SignaturePolicy node, dispatching on its oneof type: an NOutOf
+// node (e.g. NOutOf{N: 1, Rules: [SignedBy(0), SignedBy(1)]}) renders via renderNOutOf (e.g.
+// to "OR('Org1MSP.member', 'Org2MSP.member')"), a SignedBy node (e.g. SignedBy(0)) renders via
+// renderSignedBy (e.g. to "'Org1MSP.member'"), and anything else (there is no third oneof case
+// today) renders as "<unknown-rule>" in lenientMode or errors in strictMode.
+func renderRule(rule *cb.SignaturePolicy, identities []*mb.MSPPrincipal, mode renderMode) (string, error) {
+	switch t := rule.GetType().(type) {
+	case *cb.SignaturePolicy_NOutOf_:
+		return renderNOutOf(t.NOutOf, identities, mode)
+	case *cb.SignaturePolicy_SignedBy:
+		return renderSignedBy(t.SignedBy, identities, mode)
+	default:
+		if mode == strictMode {
+			return "", fmt.Errorf("policy rule has no DSL representation: %T", t)
+		}
+		return "<unknown-rule>", nil
+	}
+}
+
+// renderNOutOf renders an NOutOf node as one of the three DSL gates, picking the gate from N
+// relative to len(Rules):
+//   - no rules, e.g. NOutOf{N: 0, Rules: []} (AcceptAllPolicy) -> "OutOf(0)"
+//   - N == 1, e.g. NOutOf{N: 1, Rules: [SignedBy(0), SignedBy(1)]} -> "OR('A.member', 'B.member')"
+//   - N == len(Rules), e.g. NOutOf{N: 2, Rules: [SignedBy(0), SignedBy(1)]} -> "AND('A.member', 'B.member')"
+//   - otherwise, e.g. NOutOf{N: 2, Rules: [SignedBy(0), SignedBy(1), SignedBy(2)]} ->
+//     "OutOf(2, 'A.member', 'B.member', 'C.member')"
+//
+// N == 1 is checked before N == len(Rules) so a single-rule NOutOf renders as "OR(...)" rather
+// than "AND(...)"; both parse back to the identical envelope, so either spelling is faithful.
+func renderNOutOf(nOutOf *cb.SignaturePolicy_NOutOf, identities []*mb.MSPPrincipal, mode renderMode) (string, error) {
+	n := nOutOf.GetN()
+	rules := nOutOf.GetRules()
+
+	if len(rules) == 0 {
+		return fmt.Sprintf("%s(%d)", GateOutOfDisplay, n), nil
+	}
+
+	rendered, err := renderAll(rules, identities, mode)
+	if err != nil {
+		return "", err
+	}
+
+	switch {
+	case n == 1:
+		return fmt.Sprintf("%s(%s)", GateOrDisplay, strings.Join(rendered, ", ")), nil
+	case int(n) == len(rules):
+		return fmt.Sprintf("%s(%s)", GateAndDisplay, strings.Join(rendered, ", ")), nil
+	default:
+		return fmt.Sprintf("%s(%d, %s)", GateOutOfDisplay, n, strings.Join(rendered, ", ")), nil
+	}
+}
+
+// renderAll renders each rule in rules independently and returns the rendered strings in the
+// same order, e.g. [SignedBy(0), SignedBy(1)] -> []string{"'Org1MSP.member'", "'Org2MSP.member'"}.
+// It stops at the first error, so a single unrenderable rule fails the whole slice in strictMode.
+func renderAll(rules []*cb.SignaturePolicy, identities []*mb.MSPPrincipal, mode renderMode) ([]string, error) {
+	rendered := make([]string, len(rules))
+	for i, rule := range rules {
+		r, err := renderRule(rule, identities, mode)
+		if err != nil {
+			return nil, err
+		}
+		rendered[i] = r
+	}
+	return rendered, nil
+}
+
+// renderSignedBy resolves a SignedBy index into the corresponding identities entry and renders
+// that principal, e.g. SignedBy(0) against identities[0] = {MspIdentifier: "Org1MSP",
+// Role: MEMBER} -> "'Org1MSP.member'". An index outside the identities slice (a malformed
+// envelope) renders as "<principal[N]>" in lenientMode or errors in strictMode.
+func renderSignedBy(index int32, identities []*mb.MSPPrincipal, mode renderMode) (string, error) {
+	if index < 0 || int(index) >= len(identities) {
+		if mode == strictMode {
+			return "", fmt.Errorf("signed_by index %d out of range of %d identities", index, len(identities))
+		}
+		return fmt.Sprintf("<principal[%d]>", index), nil
+	}
+	return renderPrincipal(identities[index], index, mode)
+}
+
+// renderPrincipal renders an MSPPrincipal, dispatching on its PrincipalClassification:
+//   - ROLE, e.g. {MspIdentifier: "Org1MSP", Role: MEMBER} -> "'Org1MSP.member'" (renderRolePrincipal)
+//   - ORGANIZATION_UNIT, e.g. {MspIdentifier: "Org1MSP", OrganizationalUnitIdentifier: "eng"}
+//     -> "'Org1MSP.eng'" (renderOUPrincipal)
+//   - IDENTITY, which carries a full serialized identity with no DSL syntax -> "<identity:N>"
+//     in lenientMode (N is the identities index) or an error in strictMode
+//   - ANONYMITY / COMBINED (no DSL syntax either) -> "<principal:a1b2c3d4>" in lenientMode
+//     (hex-truncated raw bytes) or an error in strictMode
+func renderPrincipal(principal *mb.MSPPrincipal, index int32, mode renderMode) (string, error) {
+	switch principal.GetPrincipalClassification() {
+	case mb.MSPPrincipal_ROLE:
+		return renderRolePrincipal(principal, mode)
+	case mb.MSPPrincipal_ORGANIZATION_UNIT:
+		return renderOUPrincipal(principal, mode)
+	case mb.MSPPrincipal_IDENTITY:
+		if mode == strictMode {
+			return "", fmt.Errorf("identity principal at index %d has no DSL representation", index)
+		}
+		return fmt.Sprintf("<identity:%d>", index), nil
+	default:
+		if mode == strictMode {
+			return "", fmt.Errorf(
+				"principal classification %s has no DSL representation", principal.GetPrincipalClassification(),
+			)
+		}
+		return placeholderPrincipal(principal.GetPrincipal()), nil
+	}
+}
+
+// renderRolePrincipal unmarshals a ROLE principal's bytes into an MSPRole and renders it as
+// 'mspID.role', lowercasing the role, e.g. MSPRole{MspIdentifier: "Org1MSP", Role: ADMIN} ->
+// "'Org1MSP.admin'". Bytes that fail to unmarshal (corrupt data, not a client bug) render as
+// a hex placeholder in lenientMode or error in strictMode.
+func renderRolePrincipal(principal *mb.MSPPrincipal, mode renderMode) (string, error) {
+	role := &mb.MSPRole{}
+	if err := proto.Unmarshal(principal.GetPrincipal(), role); err != nil {
+		if mode == strictMode {
+			return "", fmt.Errorf("could not unmarshal MSPRole: %w", err)
+		}
+		return placeholderPrincipal(principal.GetPrincipal()), nil
+	}
+	return fmt.Sprintf("'%s.%s'", role.GetMspIdentifier(), strings.ToLower(role.GetRole().String())), nil
+}
+
+// renderOUPrincipal unmarshals an ORGANIZATION_UNIT principal's bytes into an OrganizationUnit
+// and renders it as 'mspID.ouID', e.g. OrganizationUnit{MspIdentifier: "Org1MSP",
+// OrganizationalUnitIdentifier: "engineering"} -> "'Org1MSP.engineering'". Bytes that fail to
+// unmarshal render as a hex placeholder in lenientMode or error in strictMode.
+func renderOUPrincipal(principal *mb.MSPPrincipal, mode renderMode) (string, error) {
+	ou := &mb.OrganizationUnit{}
+	if err := proto.Unmarshal(principal.GetPrincipal(), ou); err != nil {
+		if mode == strictMode {
+			return "", fmt.Errorf("could not unmarshal OrganizationUnit: %w", err)
+		}
+		return placeholderPrincipal(principal.GetPrincipal()), nil
+	}
+	return fmt.Sprintf("'%s.%s'", ou.GetMspIdentifier(), ou.GetOrganizationalUnitIdentifier()), nil
+}
+
+// placeholderPrincipal renders raw principal bytes as a hex placeholder, truncated to
+// principalPlaceholderHexLen bytes, e.g. []byte("not an MSPRole") -> "<principal:6e6f7420616e204d>".
+// Truncation matters for IDENTITY principals, which carry a full certificate: dumping it
+// untruncated would put a couple of KB of hex into the rendered string.
+func placeholderPrincipal(raw []byte) string {
+	n := min(len(raw), principalPlaceholderHexLen)
+	return "<principal:" + hex.EncodeToString(raw[:n]) + ">"
+}
+
+// Gate*Display are the canonical, human-readable gate spellings used by ToString and
+// ToDisplayString. They deliberately do not reuse GateAnd/GateOr/GateOutOf, which are the
+// lowercase parser tokens ("and"/"or"/"outof") rather than the display spelling; Visit
+// lowercases gate identifiers during AST traversal, so this casing still round-trips through
+// FromString.
+const (
+	GateAndDisplay   = "AND"
+	GateOrDisplay    = "OR"
+	GateOutOfDisplay = "OutOf"
+)

--- a/common/policydsl/policyrenderer.go
+++ b/common/policydsl/policyrenderer.go
@@ -74,7 +74,6 @@ func renderRule(rule *cb.SignaturePolicy, identities []*mb.MSPPrincipal, mode re
 
 // renderNOutOf renders an NOutOf node as one of the three DSL gates, picking the gate from N
 // relative to len(Rules):
-//   - no rules, e.g. NOutOf{N: 0, Rules: []} (AcceptAllPolicy) -> "OutOf(0)"
 //   - N == 1, e.g. NOutOf{N: 1, Rules: [SignedBy(0), SignedBy(1)]} -> "OR('A.member', 'B.member')"
 //   - N == len(Rules), e.g. NOutOf{N: 2, Rules: [SignedBy(0), SignedBy(1)]} -> "AND('A.member', 'B.member')"
 //   - otherwise, e.g. NOutOf{N: 2, Rules: [SignedBy(0), SignedBy(1), SignedBy(2)]} ->
@@ -82,11 +81,21 @@ func renderRule(rule *cb.SignaturePolicy, identities []*mb.MSPPrincipal, mode re
 //
 // N == 1 is checked before N == len(Rules) so a single-rule NOutOf renders as "OR(...)" rather
 // than "AND(...)"; both parse back to the identical envelope, so either spelling is faithful.
+//
+// An NOutOf with no rules at all, e.g. NOutOf{N: 0, Rules: []} (AcceptAllPolicy) or
+// NOutOf{N: 1, Rules: []} (RejectAllPolicy), has no DSL representation: FromString's nOutOf
+// rejects any OutOf/And/Or call with fewer than one policy argument (policyparser.go's
+// "expected at least two arguments to NOutOf"), so there is no string of the form "OutOf(N)"
+// that actually parses back to it, even though it renders as exactly that in lenientMode.
+// strictMode errors instead of emitting text FromString would reject.
 func renderNOutOf(nOutOf *cb.SignaturePolicy_NOutOf, identities []*mb.MSPPrincipal, mode renderMode) (string, error) {
 	n := nOutOf.GetN()
 	rules := nOutOf.GetRules()
 
 	if len(rules) == 0 {
+		if mode == strictMode {
+			return "", fmt.Errorf("NOutOf with no rules (n=%d) has no DSL representation", n)
+		}
 		return fmt.Sprintf("%s(%d)", GateOutOfDisplay, n), nil
 	}
 
@@ -137,7 +146,10 @@ func renderSignedBy(index int32, identities []*mb.MSPPrincipal, mode renderMode)
 // renderPrincipal renders an MSPPrincipal, dispatching on its PrincipalClassification:
 //   - ROLE, e.g. {MspIdentifier: "Org1MSP", Role: MEMBER} -> "'Org1MSP.member'" (renderRolePrincipal)
 //   - ORGANIZATION_UNIT, e.g. {MspIdentifier: "Org1MSP", OrganizationalUnitIdentifier: "eng"}
-//     -> "'Org1MSP.eng'" (renderOUPrincipal)
+//     -> "'Org1MSP.eng'" in lenientMode (renderOUPrincipal) or an error in strictMode: unlike
+//     ROLE, FromString's roleRegex only matches the five MSP role suffixes, so there is no DSL
+//     syntax for an organization unit at all, in any spelling, even though the rendered text is
+//     shaped exactly like a valid ROLE principal
 //   - IDENTITY, which carries a full serialized identity with no DSL syntax -> "<identity:N>"
 //     in lenientMode (N is the identities index) or an error in strictMode
 //   - ANONYMITY / COMBINED (no DSL syntax either) -> "<principal:a1b2c3d4>" in lenientMode
@@ -147,7 +159,10 @@ func renderPrincipal(principal *mb.MSPPrincipal, index int32, mode renderMode) (
 	case mb.MSPPrincipal_ROLE:
 		return renderRolePrincipal(principal, mode)
 	case mb.MSPPrincipal_ORGANIZATION_UNIT:
-		return renderOUPrincipal(principal, mode)
+		if mode == strictMode {
+			return "", fmt.Errorf("organization_unit principal at index %d has no DSL representation", index)
+		}
+		return renderOUPrincipal(principal), nil
 	case mb.MSPPrincipal_IDENTITY:
 		if mode == strictMode {
 			return "", fmt.Errorf("identity principal at index %d has no DSL representation", index)
@@ -180,17 +195,16 @@ func renderRolePrincipal(principal *mb.MSPPrincipal, mode renderMode) (string, e
 
 // renderOUPrincipal unmarshals an ORGANIZATION_UNIT principal's bytes into an OrganizationUnit
 // and renders it as 'mspID.ouID', e.g. OrganizationUnit{MspIdentifier: "Org1MSP",
-// OrganizationalUnitIdentifier: "engineering"} -> "'Org1MSP.engineering'". Bytes that fail to
-// unmarshal render as a hex placeholder in lenientMode or error in strictMode.
-func renderOUPrincipal(principal *mb.MSPPrincipal, mode renderMode) (string, error) {
+// OrganizationalUnitIdentifier: "engineering"} -> "'Org1MSP.engineering'". Only called from
+// renderPrincipal's lenientMode branch — ORGANIZATION_UNIT has no DSL representation at all, so
+// this text is display-only and never valid DSL, despite looking exactly like a ROLE principal.
+// Bytes that fail to unmarshal (corrupt data, not a client bug) render as a hex placeholder.
+func renderOUPrincipal(principal *mb.MSPPrincipal) string {
 	ou := &mb.OrganizationUnit{}
 	if err := proto.Unmarshal(principal.GetPrincipal(), ou); err != nil {
-		if mode == strictMode {
-			return "", fmt.Errorf("could not unmarshal OrganizationUnit: %w", err)
-		}
-		return placeholderPrincipal(principal.GetPrincipal()), nil
+		return placeholderPrincipal(principal.GetPrincipal())
 	}
-	return fmt.Sprintf("'%s.%s'", ou.GetMspIdentifier(), ou.GetOrganizationalUnitIdentifier()), nil
+	return fmt.Sprintf("'%s.%s'", ou.GetMspIdentifier(), ou.GetOrganizationalUnitIdentifier())
 }
 
 // placeholderPrincipal renders raw principal bytes as a hex placeholder, truncated to

--- a/common/policydsl/policyrenderer_test.go
+++ b/common/policydsl/policyrenderer_test.go
@@ -79,20 +79,41 @@ func TestToString_ExactRendering(t *testing.T) {
 	}
 }
 
-func TestToString_AcceptAllPolicy(t *testing.T) {
+// TestToString_EmptyNOutOfFails asserts that AcceptAllPolicy and RejectAllPolicy — both an
+// NOutOf with zero rules — have no DSL representation: FromString's nOutOf rejects any
+// OutOf/And/Or call with fewer than one policy argument, so there is no "OutOf(N)" string that
+// parses back to either. ToString must error rather than emit that unparseable text.
+func TestToString_EmptyNOutOfFails(t *testing.T) {
 	t.Parallel()
 
-	rendered, err := ToString(AcceptAllPolicy)
-	require.NoError(t, err)
-	require.Equal(t, "OutOf(0)", rendered)
+	_, err := ToString(AcceptAllPolicy)
+	require.ErrorContains(t, err, "no DSL representation")
+
+	_, err = ToString(RejectAllPolicy)
+	require.ErrorContains(t, err, "no DSL representation")
 }
 
-func TestToString_RejectAllPolicy(t *testing.T) {
+// TestToString_OrganizationUnitPrincipalFails asserts that an ORGANIZATION_UNIT principal has
+// no DSL representation: FromString's roleRegex only matches the five MSP role suffixes
+// (admin/member/client/peer/orderer), with no syntax for an organization unit at all.
+func TestToString_OrganizationUnitPrincipalFails(t *testing.T) {
 	t.Parallel()
 
-	rendered, err := ToString(RejectAllPolicy)
-	require.NoError(t, err)
-	require.Equal(t, "OutOf(1)", rendered)
+	envelope := &common.SignaturePolicyEnvelope{
+		Rule: SignedBy(0),
+		Identities: []*msp.MSPPrincipal{
+			{
+				PrincipalClassification: msp.MSPPrincipal_ORGANIZATION_UNIT,
+				Principal: protoutil.MarshalOrPanic(&msp.OrganizationUnit{
+					MspIdentifier:                "Org1MSP",
+					OrganizationalUnitIdentifier: "engineering",
+				}),
+			},
+		},
+	}
+
+	_, err := ToString(envelope)
+	require.ErrorContains(t, err, "no DSL representation")
 }
 
 func TestToString_IdentityPrincipalFails(t *testing.T) {
@@ -111,6 +132,16 @@ func TestToString_SignedByOutOfRangeFails(t *testing.T) {
 
 	_, err := ToString(envelope)
 	require.ErrorContains(t, err, "out of range")
+}
+
+// TestToDisplayString_EmptyNOutOf asserts that, unlike ToString, ToDisplayString never fails on
+// AcceptAllPolicy/RejectAllPolicy: it renders "OutOf(N)" for display purposes even though that
+// text is not actually valid DSL — FromString would reject it (see renderNOutOf).
+func TestToDisplayString_EmptyNOutOf(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "OutOf(0)", ToDisplayString(AcceptAllPolicy))
+	require.Equal(t, "OutOf(1)", ToDisplayString(RejectAllPolicy))
 }
 
 // TestToDisplayString_IdentityPrincipal asserts that, unlike ToString, ToDisplayString never

--- a/common/policydsl/policyrenderer_test.go
+++ b/common/policydsl/policyrenderer_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package policydsl
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-common/protoutil"
+	"github.com/hyperledger/fabric-x-common/utils/test"
+)
+
+// TestToString_RoundTrips asserts that rendering a policy produced by FromString and feeding
+// the result back through FromString yields a semantically identical envelope. This is the
+// load-bearing assertion: it can't be satisfied by a renderer that merely produces
+// plausible-looking text.
+func TestToString_RoundTrips(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"or of three":  "OR('Org1MSP.member', 'Org2MSP.member', 'Org3MSP.member')",
+		"and":          "AND('Org1MSP.admin', 'Org2MSP.admin')",
+		"out of":       "OutOf(2, 'A.member', 'B.member', 'C.member')",
+		"role member":  "OR('Org1MSP.member')",
+		"role admin":   "OR('Org1MSP.admin')",
+		"role client":  "OR('Org1MSP.client')",
+		"role peer":    "OR('Org1MSP.peer')",
+		"role orderer": "OR('Org1MSP.orderer')",
+		"nested tree":  "AND(OR(AND('A.member', 'B.member'), AND('A.member', 'C.member')), 'D.member')",
+	}
+
+	for name, dsl := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			envelope, err := FromString(dsl)
+			require.NoError(t, err)
+
+			rendered, err := ToString(envelope)
+			require.NoError(t, err)
+
+			roundTripped, err := FromString(rendered)
+			require.NoError(t, err, "rendered DSL %q must parse", rendered)
+			test.RequireProtoEqual(t, envelope, roundTripped)
+		})
+	}
+}
+
+// TestToString_ExactRendering pins the exact rendered string for DSL that is already in
+// canonical form, catching accidental formatting regressions (spacing, gate casing) that the
+// round-trip test alone would not.
+func TestToString_ExactRendering(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"OR('Org1MSP.member', 'Org2MSP.member', 'Org3MSP.member')",
+		"AND('Org1MSP.admin', 'Org2MSP.admin')",
+		"OR('Org1MSP.member')",
+	}
+
+	for _, dsl := range cases {
+		t.Run(dsl, func(t *testing.T) {
+			t.Parallel()
+
+			envelope, err := FromString(dsl)
+			require.NoError(t, err)
+
+			rendered, err := ToString(envelope)
+			require.NoError(t, err)
+			require.Equal(t, dsl, rendered)
+		})
+	}
+}
+
+func TestToString_AcceptAllPolicy(t *testing.T) {
+	t.Parallel()
+
+	rendered, err := ToString(AcceptAllPolicy)
+	require.NoError(t, err)
+	require.Equal(t, "OutOf(0)", rendered)
+}
+
+func TestToString_RejectAllPolicy(t *testing.T) {
+	t.Parallel()
+
+	rendered, err := ToString(RejectAllPolicy)
+	require.NoError(t, err)
+	require.Equal(t, "OutOf(1)", rendered)
+}
+
+func TestToString_IdentityPrincipalFails(t *testing.T) {
+	t.Parallel()
+
+	envelope := Envelope(SignedBy(0), [][]byte{[]byte("a serialized identity")})
+
+	_, err := ToString(envelope)
+	require.ErrorContains(t, err, "no DSL representation")
+}
+
+func TestToString_SignedByOutOfRangeFails(t *testing.T) {
+	t.Parallel()
+
+	envelope := &common.SignaturePolicyEnvelope{Rule: SignedBy(0)}
+
+	_, err := ToString(envelope)
+	require.ErrorContains(t, err, "out of range")
+}
+
+// TestToDisplayString_IdentityPrincipal asserts that, unlike ToString, ToDisplayString never
+// fails on a construct with no DSL representation: it substitutes a readable placeholder.
+// Envelope() classifies every identity as IDENTITY, so this exercises that placeholder path.
+func TestToDisplayString_IdentityPrincipal(t *testing.T) {
+	t.Parallel()
+
+	envelope := Envelope(SignedBy(0), [][]byte{[]byte("a serialized identity")})
+
+	require.Equal(t, "<identity:0>", ToDisplayString(envelope))
+}
+
+func TestToDisplayString_SignedByOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	envelope := &common.SignaturePolicyEnvelope{Rule: SignedBy(0)}
+
+	require.Equal(t, "<principal[0]>", ToDisplayString(envelope))
+}
+
+// TestToDisplayString_MalformedPrincipalFallsBackToPlaceholder asserts that a ROLE-classified
+// principal whose bytes don't unmarshal into an MSPRole (corrupt data, not a client bug) still
+// renders as a placeholder instead of panicking.
+func TestToDisplayString_MalformedPrincipalFallsBackToPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	envelope := &common.SignaturePolicyEnvelope{
+		Rule: SignedBy(0),
+		Identities: []*msp.MSPPrincipal{
+			{PrincipalClassification: msp.MSPPrincipal_ROLE, Principal: []byte("not an MSPRole")},
+		},
+	}
+
+	require.Equal(t, "<principal:6e6f7420616e204d>", ToDisplayString(envelope))
+}
+
+func TestToDisplayString_OrganizationUnitPrincipal(t *testing.T) {
+	t.Parallel()
+
+	envelope := &common.SignaturePolicyEnvelope{
+		Rule: SignedBy(0),
+		Identities: []*msp.MSPPrincipal{
+			{
+				PrincipalClassification: msp.MSPPrincipal_ORGANIZATION_UNIT,
+				Principal: protoutil.MarshalOrPanic(&msp.OrganizationUnit{
+					MspIdentifier:                "Org1MSP",
+					OrganizationalUnitIdentifier: "engineering",
+				}),
+			},
+		},
+	}
+
+	require.Equal(t, "'Org1MSP.engineering'", ToDisplayString(envelope))
+}

--- a/common/policydsl/policyrenderer_test.go
+++ b/common/policydsl/policyrenderer_test.go
@@ -134,6 +134,18 @@ func TestToString_SignedByOutOfRangeFails(t *testing.T) {
 	require.ErrorContains(t, err, "out of range")
 }
 
+// TestToString_UnknownRuleFails asserts that a SignaturePolicy with neither oneof case set,
+// e.g. an envelope with no Rule at all, has no DSL representation: SignaturePolicy is a oneof
+// of NOutOf and SignedBy, and a zero-value rule matches neither.
+func TestToString_UnknownRuleFails(t *testing.T) {
+	t.Parallel()
+
+	envelope := &common.SignaturePolicyEnvelope{Rule: &common.SignaturePolicy{}}
+
+	_, err := ToString(envelope)
+	require.ErrorContains(t, err, "no DSL representation")
+}
+
 // TestToDisplayString_EmptyNOutOf asserts that, unlike ToString, ToDisplayString never fails on
 // AcceptAllPolicy/RejectAllPolicy: it renders "OutOf(N)" for display purposes even though that
 // text is not actually valid DSL — FromString would reject it (see renderNOutOf).
@@ -163,6 +175,14 @@ func TestToDisplayString_SignedByOutOfRange(t *testing.T) {
 	require.Equal(t, "<principal[0]>", ToDisplayString(envelope))
 }
 
+func TestToDisplayString_UnknownRule(t *testing.T) {
+	t.Parallel()
+
+	envelope := &common.SignaturePolicyEnvelope{Rule: &common.SignaturePolicy{}}
+
+	require.Equal(t, "<unknown-rule>", ToDisplayString(envelope))
+}
+
 // TestToDisplayString_MalformedPrincipalFallsBackToPlaceholder asserts that a ROLE-classified
 // principal whose bytes don't unmarshal into an MSPRole (corrupt data, not a client bug) still
 // renders as a placeholder instead of panicking.
@@ -176,7 +196,7 @@ func TestToDisplayString_MalformedPrincipalFallsBackToPlaceholder(t *testing.T) 
 		},
 	}
 
-	require.Equal(t, "<principal:6e6f7420616e204d>", ToDisplayString(envelope))
+	require.Equal(t, "<principal:bm90IGFuIE0=>", ToDisplayString(envelope))
 }
 
 func TestToDisplayString_OrganizationUnitPrincipal(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Add `ToString`/`ToDisplayString` to `common/policydsl`, the exact inverse of `FromString`: they render a `*cb.SignaturePolicyEnvelope` back into the policy DSL string it was parsed from (e.g. `OR('Org1MSP.member', 'Org2MSP.member')`).

No renderer existed anywhere in this codebase or its consumers — `fxconfig` even has a commented-out `parsePolicy` with `// TODO: some pretty print would be beautiful`. Consumers that store a `SignaturePolicyEnvelope` (e.g. an MSP-based endorsement policy) have no way to show it back to a user except as raw, unreadable protobuf bytes.

- `ToString` returns an error if any part of the policy has no DSL representation (a bare `IDENTITY` principal, an out-of-range `signed_by`, an unsupported principal classification).
- `ToDisplayString` never fails: it substitutes a readable placeholder (e.g. `<identity:0>`, `<principal:a1b2c3d4>`) for anything unrenderable instead of erroring.

Both share one recursive tree walk parameterized by a strict/lenient mode, so there is a single implementation of the rendering logic behind the two entry points.

