### PR TITLE
add block_hash and prev_block_hash to TxEventBatch

### DIFF
--- a/api/committerpb/notify.pb.go
+++ b/api/committerpb/notify.pb.go
@@ -288,8 +288,8 @@ func (x *StreamAllRequest) GetIncludeMetadata() bool {
 	return false
 }
 
-// TxEventBatch contains a batch of transaction events from a single block.
-type TxEventBatch struct {
+// BlockEvent contains a batch of transaction events from a single block.
+type BlockEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The block number from which these transactions originated.
 	BlockNumber uint64 `protobuf:"varint,1,opt,name=block_number,json=blockNumber,proto3" json:"block_number,omitempty"`
@@ -303,20 +303,20 @@ type TxEventBatch struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *TxEventBatch) Reset() {
-	*x = TxEventBatch{}
+func (x *BlockEvent) Reset() {
+	*x = BlockEvent{}
 	mi := &file_api_committerpb_notify_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *TxEventBatch) String() string {
+func (x *BlockEvent) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*TxEventBatch) ProtoMessage() {}
+func (*BlockEvent) ProtoMessage() {}
 
-func (x *TxEventBatch) ProtoReflect() protoreflect.Message {
+func (x *BlockEvent) ProtoReflect() protoreflect.Message {
 	mi := &file_api_committerpb_notify_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -328,33 +328,33 @@ func (x *TxEventBatch) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use TxEventBatch.ProtoReflect.Descriptor instead.
-func (*TxEventBatch) Descriptor() ([]byte, []int) {
+// Deprecated: Use BlockEvent.ProtoReflect.Descriptor instead.
+func (*BlockEvent) Descriptor() ([]byte, []int) {
 	return file_api_committerpb_notify_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *TxEventBatch) GetBlockNumber() uint64 {
+func (x *BlockEvent) GetBlockNumber() uint64 {
 	if x != nil {
 		return x.BlockNumber
 	}
 	return 0
 }
 
-func (x *TxEventBatch) GetEvents() []*TxEvent {
+func (x *BlockEvent) GetEvents() []*TxEvent {
 	if x != nil {
 		return x.Events
 	}
 	return nil
 }
 
-func (x *TxEventBatch) GetBlockHash() []byte {
+func (x *BlockEvent) GetBlockHash() []byte {
 	if x != nil {
 		return x.BlockHash
 	}
 	return nil
 }
 
-func (x *TxEventBatch) GetPrevBlockHash() []byte {
+func (x *BlockEvent) GetPrevBlockHash() []byte {
 	if x != nil {
 		return x.PrevBlockHash
 	}
@@ -468,8 +468,9 @@ const file_api_committerpb_notify_proto_rawDesc = "" +
 	"\rfilter_status\x18\x02 \x03(\x0e2\x13.committerpb.StatusR\ffilterStatus\x125\n" +
 	"\x17include_read_write_sets\x18\x03 \x01(\bR\x14includeReadWriteSets\x121\n" +
 	"\x14include_endorsements\x18\x04 \x01(\bR\x13includeEndorsements\x12)\n" +
-	"\x10include_metadata\x18\x05 \x01(\bR\x0fincludeMetadata\"\xa6\x01\n" +
-	"\fTxEventBatch\x12!\n" +
+	"\x10include_metadata\x18\x05 \x01(\bR\x0fincludeMetadata\"\xa4\x01\n" +
+	"\n" +
+	"BlockEvent\x12!\n" +
 	"\fblock_number\x18\x01 \x01(\x04R\vblockNumber\x12,\n" +
 	"\x06events\x18\x02 \x03(\v2\x14.committerpb.TxEventR\x06events\x12\x1d\n" +
 	"\n" +
@@ -482,10 +483,10 @@ const file_api_committerpb_notify_proto_rawDesc = "" +
 	"namespaces\x18\x03 \x03(\v2\x1a.applicationpb.TxNamespaceR\n" +
 	"namespaces\x12?\n" +
 	"\fendorsements\x18\x04 \x03(\v2\x1b.applicationpb.EndorsementsR\fendorsements\x12\x1a\n" +
-	"\bmetadata\x18\x05 \x03(\fR\bmetadata2\xc2\x01\n" +
+	"\bmetadata\x18\x05 \x03(\fR\bmetadata2\xc0\x01\n" +
 	"\bNotifier\x12a\n" +
-	"\x16OpenNotificationStream\x12 .committerpb.NotificationRequest\x1a!.committerpb.NotificationResponse(\x010\x01\x12S\n" +
-	"\x15StreamAllTransactions\x12\x1d.committerpb.StreamAllRequest\x1a\x19.committerpb.TxEventBatch0\x01B8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
+	"\x16OpenNotificationStream\x12 .committerpb.NotificationRequest\x1a!.committerpb.NotificationResponse(\x010\x01\x12Q\n" +
+	"\x15StreamAllTransactions\x12\x1d.committerpb.StreamAllRequest\x1a\x17.committerpb.BlockEvent0\x01B8Z6github.com/hyperledger/fabric-x-common/api/committerpbb\x06proto3"
 
 var (
 	file_api_committerpb_notify_proto_rawDescOnce sync.Once
@@ -505,7 +506,7 @@ var file_api_committerpb_notify_proto_goTypes = []any{
 	(*NotificationResponse)(nil),       // 1: committerpb.NotificationResponse
 	(*RejectedTxIds)(nil),              // 2: committerpb.RejectedTxIds
 	(*StreamAllRequest)(nil),           // 3: committerpb.StreamAllRequest
-	(*TxEventBatch)(nil),               // 4: committerpb.TxEventBatch
+	(*BlockEvent)(nil),                 // 4: committerpb.BlockEvent
 	(*TxEvent)(nil),                    // 5: committerpb.TxEvent
 	(*TxIDsBatch)(nil),                 // 6: committerpb.TxIDsBatch
 	(*durationpb.Duration)(nil),        // 7: google.protobuf.Duration
@@ -521,7 +522,7 @@ var file_api_committerpb_notify_proto_depIdxs = []int32{
 	8,  // 2: committerpb.NotificationResponse.tx_status_events:type_name -> committerpb.TxStatus
 	2,  // 3: committerpb.NotificationResponse.rejected_tx_ids:type_name -> committerpb.RejectedTxIds
 	9,  // 4: committerpb.StreamAllRequest.filter_status:type_name -> committerpb.Status
-	5,  // 5: committerpb.TxEventBatch.events:type_name -> committerpb.TxEvent
+	5,  // 5: committerpb.BlockEvent.events:type_name -> committerpb.TxEvent
 	10, // 6: committerpb.TxEvent.ref:type_name -> committerpb.TxRef
 	9,  // 7: committerpb.TxEvent.status:type_name -> committerpb.Status
 	11, // 8: committerpb.TxEvent.namespaces:type_name -> applicationpb.TxNamespace
@@ -529,7 +530,7 @@ var file_api_committerpb_notify_proto_depIdxs = []int32{
 	0,  // 10: committerpb.Notifier.OpenNotificationStream:input_type -> committerpb.NotificationRequest
 	3,  // 11: committerpb.Notifier.StreamAllTransactions:input_type -> committerpb.StreamAllRequest
 	1,  // 12: committerpb.Notifier.OpenNotificationStream:output_type -> committerpb.NotificationResponse
-	4,  // 13: committerpb.Notifier.StreamAllTransactions:output_type -> committerpb.TxEventBatch
+	4,  // 13: committerpb.Notifier.StreamAllTransactions:output_type -> committerpb.BlockEvent
 	12, // [12:14] is the sub-list for method output_type
 	10, // [10:12] is the sub-list for method input_type
 	10, // [10:10] is the sub-list for extension type_name

--- a/api/committerpb/notify.pb.go
+++ b/api/committerpb/notify.pb.go
@@ -294,7 +294,11 @@ type TxEventBatch struct {
 	// The block number from which these transactions originated.
 	BlockNumber uint64 `protobuf:"varint,1,opt,name=block_number,json=blockNumber,proto3" json:"block_number,omitempty"`
 	// List of transaction events (may be filtered based on request).
-	Events        []*TxEvent `protobuf:"bytes,2,rep,name=events,proto3" json:"events,omitempty"`
+	Events []*TxEvent `protobuf:"bytes,2,rep,name=events,proto3" json:"events,omitempty"`
+	// The hash of the block from which these transactions originated.
+	BlockHash []byte `protobuf:"bytes,3,opt,name=block_hash,json=blockHash,proto3" json:"block_hash,omitempty"`
+	// The hash of the previous block.
+	PrevBlockHash []byte `protobuf:"bytes,4,opt,name=prev_block_hash,json=prevBlockHash,proto3" json:"prev_block_hash,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -339,6 +343,20 @@ func (x *TxEventBatch) GetBlockNumber() uint64 {
 func (x *TxEventBatch) GetEvents() []*TxEvent {
 	if x != nil {
 		return x.Events
+	}
+	return nil
+}
+
+func (x *TxEventBatch) GetBlockHash() []byte {
+	if x != nil {
+		return x.BlockHash
+	}
+	return nil
+}
+
+func (x *TxEventBatch) GetPrevBlockHash() []byte {
+	if x != nil {
+		return x.PrevBlockHash
 	}
 	return nil
 }
@@ -450,10 +468,13 @@ const file_api_committerpb_notify_proto_rawDesc = "" +
 	"\rfilter_status\x18\x02 \x03(\x0e2\x13.committerpb.StatusR\ffilterStatus\x125\n" +
 	"\x17include_read_write_sets\x18\x03 \x01(\bR\x14includeReadWriteSets\x121\n" +
 	"\x14include_endorsements\x18\x04 \x01(\bR\x13includeEndorsements\x12)\n" +
-	"\x10include_metadata\x18\x05 \x01(\bR\x0fincludeMetadata\"_\n" +
+	"\x10include_metadata\x18\x05 \x01(\bR\x0fincludeMetadata\"\xa6\x01\n" +
 	"\fTxEventBatch\x12!\n" +
 	"\fblock_number\x18\x01 \x01(\x04R\vblockNumber\x12,\n" +
-	"\x06events\x18\x02 \x03(\v2\x14.committerpb.TxEventR\x06events\"\xf5\x01\n" +
+	"\x06events\x18\x02 \x03(\v2\x14.committerpb.TxEventR\x06events\x12\x1d\n" +
+	"\n" +
+	"block_hash\x18\x03 \x01(\fR\tblockHash\x12&\n" +
+	"\x0fprev_block_hash\x18\x04 \x01(\fR\rprevBlockHash\"\xf5\x01\n" +
 	"\aTxEvent\x12$\n" +
 	"\x03ref\x18\x01 \x01(\v2\x12.committerpb.TxRefR\x03ref\x12+\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x13.committerpb.StatusR\x06status\x12:\n" +

--- a/api/committerpb/notify.proto
+++ b/api/committerpb/notify.proto
@@ -81,6 +81,12 @@ message TxEventBatch {
 
     // List of transaction events (may be filtered based on request).
     repeated TxEvent events = 2;
+
+    // The hash of the block from which these transactions originated.
+    bytes block_hash = 3;
+
+    // The hash of the previous block.
+    bytes prev_block_hash = 4;
 }
 
 // TxEvent represents a single transaction event.

--- a/api/committerpb/notify.proto
+++ b/api/committerpb/notify.proto
@@ -22,7 +22,7 @@ service Notifier {
 
     // StreamAllTransactions allows clients to subscribe to all committed transactions
     // with optional filtering by namespace and status.
-    rpc StreamAllTransactions (StreamAllRequest) returns (stream TxEventBatch);
+    rpc StreamAllTransactions (StreamAllRequest) returns (stream BlockEvent);
 }
 
 // NotificationRequest is sent by the clients to subscribe to events.
@@ -74,8 +74,8 @@ message StreamAllRequest {
     bool include_metadata = 5;
 }
 
-// TxEventBatch contains a batch of transaction events from a single block.
-message TxEventBatch {
+// BlockEvent contains a batch of transaction events from a single block.
+message BlockEvent {
     // The block number from which these transactions originated.
     uint64 block_number = 1;
 

--- a/api/committerpb/notify_grpc.pb.go
+++ b/api/committerpb/notify_grpc.pb.go
@@ -37,7 +37,7 @@ type NotifierClient interface {
 	OpenNotificationStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[NotificationRequest, NotificationResponse], error)
 	// StreamAllTransactions allows clients to subscribe to all committed transactions
 	// with optional filtering by namespace and status.
-	StreamAllTransactions(ctx context.Context, in *StreamAllRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[TxEventBatch], error)
+	StreamAllTransactions(ctx context.Context, in *StreamAllRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[BlockEvent], error)
 }
 
 type notifierClient struct {
@@ -61,13 +61,13 @@ func (c *notifierClient) OpenNotificationStream(ctx context.Context, opts ...grp
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Notifier_OpenNotificationStreamClient = grpc.BidiStreamingClient[NotificationRequest, NotificationResponse]
 
-func (c *notifierClient) StreamAllTransactions(ctx context.Context, in *StreamAllRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[TxEventBatch], error) {
+func (c *notifierClient) StreamAllTransactions(ctx context.Context, in *StreamAllRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[BlockEvent], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &Notifier_ServiceDesc.Streams[1], Notifier_StreamAllTransactions_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &grpc.GenericClientStream[StreamAllRequest, TxEventBatch]{ClientStream: stream}
+	x := &grpc.GenericClientStream[StreamAllRequest, BlockEvent]{ClientStream: stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (c *notifierClient) StreamAllTransactions(ctx context.Context, in *StreamAl
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type Notifier_StreamAllTransactionsClient = grpc.ServerStreamingClient[TxEventBatch]
+type Notifier_StreamAllTransactionsClient = grpc.ServerStreamingClient[BlockEvent]
 
 // NotifierServer is the server API for Notifier service.
 // All implementations must embed UnimplementedNotifierServer
@@ -89,7 +89,7 @@ type NotifierServer interface {
 	OpenNotificationStream(grpc.BidiStreamingServer[NotificationRequest, NotificationResponse]) error
 	// StreamAllTransactions allows clients to subscribe to all committed transactions
 	// with optional filtering by namespace and status.
-	StreamAllTransactions(*StreamAllRequest, grpc.ServerStreamingServer[TxEventBatch]) error
+	StreamAllTransactions(*StreamAllRequest, grpc.ServerStreamingServer[BlockEvent]) error
 	mustEmbedUnimplementedNotifierServer()
 }
 
@@ -103,7 +103,7 @@ type UnimplementedNotifierServer struct{}
 func (UnimplementedNotifierServer) OpenNotificationStream(grpc.BidiStreamingServer[NotificationRequest, NotificationResponse]) error {
 	return status.Error(codes.Unimplemented, "method OpenNotificationStream not implemented")
 }
-func (UnimplementedNotifierServer) StreamAllTransactions(*StreamAllRequest, grpc.ServerStreamingServer[TxEventBatch]) error {
+func (UnimplementedNotifierServer) StreamAllTransactions(*StreamAllRequest, grpc.ServerStreamingServer[BlockEvent]) error {
 	return status.Error(codes.Unimplemented, "method StreamAllTransactions not implemented")
 }
 func (UnimplementedNotifierServer) mustEmbedUnimplementedNotifierServer() {}
@@ -139,11 +139,11 @@ func _Notifier_StreamAllTransactions_Handler(srv interface{}, stream grpc.Server
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(NotifierServer).StreamAllTransactions(m, &grpc.GenericServerStream[StreamAllRequest, TxEventBatch]{ServerStream: stream})
+	return srv.(NotifierServer).StreamAllTransactions(m, &grpc.GenericServerStream[StreamAllRequest, BlockEvent]{ServerStream: stream})
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type Notifier_StreamAllTransactionsServer = grpc.ServerStreamingServer[TxEventBatch]
+type Notifier_StreamAllTransactionsServer = grpc.ServerStreamingServer[BlockEvent]
 
 // Notifier_ServiceDesc is the grpc.ServiceDesc for Notifier service.
 // It's only intended for direct use with grpc.RegisterService,


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Adds two fields to the TxEventBatch, the return object from StreamAllTransactions of the committer's Notifier. See the related issue on fabric-x-committer for more details.

#### Related issues

https://github.com/hyperledger/fabric-x-committer/issues/773

