### PR TITLE
[blkstorage] Do not build tx index information no index will read

### DIFF
--- a/common/ledger/blkstorage/block_serialization.go
+++ b/common/ledger/blkstorage/block_serialization.go
@@ -26,14 +26,40 @@ type txindexInfo struct {
 	loc  *locPointer
 }
 
-func serializeBlock(block *common.Block) ([]byte, *serializedBlockInfo) {
-	var buf []byte
-	info := &serializedBlockInfo{}
-	info.blockHeader = block.Header
-	info.metadata = block.Metadata
-	buf = addHeaderBytes(block.Header, buf)
-	info.txOffsets, buf = addDataBytesAndConstructTxIndexInfo(block.Data, buf)
-	buf = addMetadataBytes(block.Metadata, buf)
+// indexNeeds says which of the per transaction facts an index will actually read back out
+// of a serialized block. Serialization sits on the critical path of every append, and both
+// of these cost real work at block scale: the offsets are an allocation per transaction,
+// and a txID is a full envelope unmarshal each. Neither is produced unless an index reads
+// it -- see blockIndex.indexBlock, where txOffsets is touched only under
+// IndexableAttrTxID or IndexableAttrBlockNumTranNum, and txID only under the former.
+type indexNeeds struct {
+	txOffsets bool
+	txIDs     bool
+}
+
+// allIndexNeeds asks for everything serialization can produce. For callers with no index to
+// consult, which is what the block store's own tests and the read-back paths want.
+var allIndexNeeds = indexNeeds{txOffsets: true, txIDs: true}
+
+func serializeBlock(block *common.Block, needs indexNeeds) ([]byte, *serializedBlockInfo) {
+	buf := make([]byte, 0, serializedBlockSize(block))
+	buf = appendHeaderBytes(buf, block.Header)
+	buf = protowire.AppendVarint(buf, uint64(len(block.Data.Data)))
+	dataStart := len(buf)
+	for _, txEnvelopeBytes := range block.Data.Data {
+		buf = protowire.AppendBytes(buf, txEnvelopeBytes)
+	}
+	buf = appendMetadataBytes(buf, block.Metadata)
+
+	info := &serializedBlockInfo{
+		blockHeader: block.Header,
+		metadata:    block.Metadata,
+	}
+	// Nothing reads the offsets back, or there are none to build: return the nil slice that
+	// extractData also returns for an empty block.
+	if needs.txOffsets && len(block.Data.Data) > 0 {
+		info.txOffsets = constructTxIndexInfo(block.Data.Data, dataStart, needs)
+	}
 	return buf, info
 }
 
@@ -73,32 +99,69 @@ func extractSerializedBlockInfo(serializedBlockBytes []byte) (*serializedBlockIn
 	return info, nil
 }
 
-func addHeaderBytes(blockHeader *common.BlockHeader, buf []byte) []byte {
+// serializedBlockSize is the exact length serializeBlock produces, so the buffer is
+// allocated once up front rather than grown a few times per block. It mirrors the writers
+// below: every protowire.Append call has a Size counterpart of the same shape.
+func serializedBlockSize(block *common.Block) int {
+	size := protowire.SizeVarint(block.Header.Number) +
+		protowire.SizeBytes(len(block.Header.DataHash)) +
+		protowire.SizeBytes(len(block.Header.PreviousHash)) +
+		protowire.SizeVarint(uint64(len(block.Data.Data)))
+	for _, txEnvelopeBytes := range block.Data.Data {
+		size += protowire.SizeBytes(len(txEnvelopeBytes))
+	}
+
+	var metadata [][]byte
+	if block.Metadata != nil {
+		metadata = block.Metadata.Metadata
+	}
+	size += protowire.SizeVarint(uint64(len(metadata)))
+	for _, b := range metadata {
+		size += protowire.SizeBytes(len(b))
+	}
+	return size
+}
+
+func appendHeaderBytes(buf []byte, blockHeader *common.BlockHeader) []byte {
 	buf = protowire.AppendVarint(buf, blockHeader.Number)
 	buf = protowire.AppendBytes(buf, blockHeader.DataHash)
 	buf = protowire.AppendBytes(buf, blockHeader.PreviousHash)
 	return buf
 }
 
-func addDataBytesAndConstructTxIndexInfo(blockData *common.BlockData, buf []byte) ([]*txindexInfo, []byte) {
-	var txOffsets []*txindexInfo
+// constructTxIndexInfo locates each envelope in the block bytes without re-reading them:
+// serializeBlock wrote them consecutively from dataStart, each as a length prefix followed by
+// the envelope, so protowire.SizeBytes gives the span of each.
+// The infos and their locations come out of one backing array each rather than two
+// allocations per transaction; the elements are only ever addressed, never copied out, so
+// pointers into them are stable for as long as the slices are.
+func constructTxIndexInfo(txEnvelopes [][]byte, dataStart int, needs indexNeeds) []*txindexInfo {
+	infos := make([]txindexInfo, len(txEnvelopes))
+	locs := make([]locPointer, len(txEnvelopes))
+	txOffsets := make([]*txindexInfo, len(txEnvelopes))
 
-	buf = protowire.AppendVarint(buf, uint64(len(blockData.Data)))
-	for _, txEnvelopeBytes := range blockData.Data {
-		offset := len(buf)
-		txid, err := protoutil.GetOrComputeTxIDFromEnvelope(txEnvelopeBytes)
-		if err != nil {
-			logger.Warningf("error while extracting txid from tx envelope bytes during serialization of block. Ignoring this error as this is caused by a malformed transaction. Error:%s",
-				err)
+	offset := dataStart
+	for i, txEnvelopeBytes := range txEnvelopes {
+		size := protowire.SizeBytes(len(txEnvelopeBytes))
+		locs[i] = locPointer{offset, size}
+		offset += size
+
+		if needs.txIDs {
+			txid, err := protoutil.GetOrComputeTxIDFromEnvelope(txEnvelopeBytes)
+			if err != nil {
+				logger.Warningf("error while extracting txid from tx envelope bytes during "+
+					"serialization of block. Ignoring this error as this is caused by a "+
+					"malformed transaction. Error:%s", err)
+			}
+			infos[i].txID = txid
 		}
-		buf = protowire.AppendBytes(buf, txEnvelopeBytes)
-		idxInfo := &txindexInfo{txID: txid, loc: &locPointer{offset, len(buf) - offset}}
-		txOffsets = append(txOffsets, idxInfo)
+		infos[i].loc = &locs[i]
+		txOffsets[i] = &infos[i]
 	}
-	return txOffsets, buf
+	return txOffsets
 }
 
-func addMetadataBytes(blockMetadata *common.BlockMetadata, buf []byte) []byte {
+func appendMetadataBytes(buf []byte, blockMetadata *common.BlockMetadata) []byte {
 	numItems := uint64(0)
 	if blockMetadata != nil {
 		numItems = uint64(len(blockMetadata.Metadata))

--- a/common/ledger/blkstorage/block_serialization_test.go
+++ b/common/ledger/blkstorage/block_serialization_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package blkstorage
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -38,7 +39,7 @@ func TestBlockSerialization(t *testing.T) {
 		}),
 	})
 
-	bb, _ := serializeBlock(block)
+	bb, _ := serializeBlock(block, allIndexNeeds)
 	deserializedBlock, err := deserializeBlock(bb)
 	require.NoError(t, err)
 	require.Equal(t, block, deserializedBlock)
@@ -87,7 +88,7 @@ func TestSerializedBlockInfo(t *testing.T) {
 }
 
 func testSerializedBlockInfo(t *testing.T, block *common.Block, c *testutilTxIDComputator) {
-	bb, info := serializeBlock(block)
+	bb, info := serializeBlock(block, allIndexNeeds)
 	infoFromBB, err := extractSerializedBlockInfo(bb)
 	require.NoError(t, err)
 	require.Equal(t, info, infoFromBB)
@@ -126,4 +127,145 @@ func (c *testutilTxIDComputator) computeExpectedTxID(txNum int, txEnvBytes []byt
 
 func (c *testutilTxIDComputator) reset() {
 	c.malformedTxNums = map[int]struct{}{}
+}
+
+// TestSerializeBlockIndexNeeds pins the two things a caller relies on when it asks for less
+// than everything: the bytes on disk do not change, and what it did not ask for is absent.
+func TestSerializeBlockIndexNeeds(t *testing.T) {
+	t.Parallel()
+	block := testutil.ConstructTestBlock(t, 1, 10, 100)
+	fullBytes, fullInfo := serializeBlock(block, allIndexNeeds)
+
+	t.Run("offsets without txIDs", func(t *testing.T) {
+		t.Parallel()
+		bb, info := serializeBlock(block, indexNeeds{txOffsets: true})
+		require.Equal(t, fullBytes, bb)
+		require.Len(t, info.txOffsets, len(block.Data.Data))
+		for txIndex, offset := range info.txOffsets {
+			require.Empty(t, offset.txID)
+			require.Equal(t, fullInfo.txOffsets[txIndex].loc, offset.loc)
+		}
+	})
+
+	t.Run("neither offsets nor txIDs", func(t *testing.T) {
+		t.Parallel()
+		bb, info := serializeBlock(block, indexNeeds{})
+		require.Equal(t, fullBytes, bb)
+		require.Nil(t, info.txOffsets)
+		require.Equal(t, block.Header, info.blockHeader)
+		require.Equal(t, block.Metadata, info.metadata)
+	})
+
+	t.Run("a block with no transactions has no offsets", func(t *testing.T) {
+		t.Parallel()
+		empty := testutil.ConstructTestBlock(t, 1, 0, 0)
+		for _, needs := range []indexNeeds{allIndexNeeds, {txOffsets: true}, {}} {
+			bb, info := serializeBlock(empty, needs)
+			require.Nil(t, info.txOffsets)
+			infoFromBB, err := extractSerializedBlockInfo(bb)
+			require.NoError(t, err)
+			require.Equal(t, info, infoFromBB)
+		}
+	})
+
+	t.Run("the block reads back whatever was asked for", func(t *testing.T) {
+		t.Parallel()
+		for _, needs := range []indexNeeds{allIndexNeeds, {txOffsets: true}, {}} {
+			bb, _ := serializeBlock(block, needs)
+			deserialized, err := deserializeBlock(bb)
+			require.NoError(t, err)
+			require.Equal(t, block, deserialized)
+		}
+	})
+}
+
+// TestBlockIndexSerializationNeeds checks that the index asks for exactly what indexBlock
+// reads. The txID index needs both; the blockNum-tranNum index needs the offsets only; a
+// block-number-only index, which is what a committer sidecar with the txID index disabled
+// configures, needs neither.
+func TestBlockIndexSerializationNeeds(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		attrs []IndexableAttr
+		want  indexNeeds
+	}{
+		{"txID", []IndexableAttr{IndexableAttrTxID}, indexNeeds{txOffsets: true, txIDs: true}},
+		{"blockNumTranNum", []IndexableAttr{IndexableAttrBlockNumTranNum}, indexNeeds{txOffsets: true}},
+		{"blockNum only", []IndexableAttr{IndexableAttrBlockNum}, indexNeeds{}},
+		{"nothing", nil, indexNeeds{}},
+		{
+			"txID and blockNum",
+			[]IndexableAttr{IndexableAttrTxID, IndexableAttrBlockNum},
+			indexNeeds{txOffsets: true, txIDs: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			index := &blockIndex{indexItemsMap: map[IndexableAttr]bool{}}
+			for _, attr := range tc.attrs {
+				index.indexItemsMap[attr] = true
+			}
+			require.Equal(t, tc.want, index.serializationNeeds())
+		})
+	}
+}
+
+// TestSerializedBlockSizeIsExact pins serializedBlockSize to what serializeBlock actually
+// writes. An exact pre-allocation means the buffer was never grown, so the returned slice's
+// capacity equals its length; an over-estimate leaves slack and an under-estimate reallocates.
+func TestSerializedBlockSizeIsExact(t *testing.T) {
+	t.Parallel()
+	noMetadata := testutil.ConstructTestBlock(t, 1, 3, 50)
+	noMetadata.Metadata = nil
+
+	for _, tc := range []struct {
+		name  string
+		block *common.Block
+	}{
+		{"full block", testutil.ConstructTestBlock(t, 1, 10, 100)},
+		{"no transactions", testutil.ConstructTestBlock(t, 1, 0, 0)},
+		{"no metadata", noMetadata},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			bb, _ := serializeBlock(tc.block, allIndexNeeds)
+			require.Equal(t, len(bb), cap(bb), "serializedBlockSize is not exact")
+		})
+	}
+}
+
+// BenchmarkSerializeBlock measures serialization, which sits on the critical path of every
+// append, across the index configurations a store can be in: the txID index needs both the
+// IDs and the offsets, the blockNum-tranNum index only the offsets, and a block-number-only
+// store -- a committer sidecar with the txID index disabled -- neither.
+func BenchmarkSerializeBlock(b *testing.B) {
+	for _, size := range []struct{ numTx, txSize int }{{10, 100}, {500, 300}, {10000, 300}} {
+		block := constructBenchmarkBlocks(b, 2, size.numTx, size.txSize)[1]
+		for _, tc := range []struct {
+			name  string
+			needs indexNeeds
+		}{
+			{"allIndexes", allIndexNeeds},
+			{"offsetsOnly", indexNeeds{txOffsets: true}},
+			{"noIndex", indexNeeds{}},
+		} {
+			b.Run(fmt.Sprintf("numTx=%d/txSize=%d/%s", size.numTx, size.txSize, tc.name), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					serializeBlock(block, tc.needs)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkSerializedBlockSize measures the pre-allocation size pass on its own. It walks the
+// envelopes a second time, so it has to stay cheap next to the buffer growth it saves.
+func BenchmarkSerializedBlockSize(b *testing.B) {
+	block := constructBenchmarkBlocks(b, 2, 10000, 300)[1]
+	b.ReportAllocs()
+	for b.Loop() {
+		serializedBlockSize(block)
+	}
 }

--- a/common/ledger/blkstorage/blockfile_helper_test.go
+++ b/common/ledger/blkstorage/blockfile_helper_test.go
@@ -63,7 +63,7 @@ func TestConstructBlockfilesInfo(t *testing.T) {
 
 	// Write a partial block (to simulate a crash) and verify that blockfilesInfo derived from filesystem should be same as from the blockfile manager
 	lastTestBlk := bg.NextTestBlocks(1)[0]
-	blockBytes, _ := serializeBlock(lastTestBlk)
+	blockBytes, _ := serializeBlock(lastTestBlk, allIndexNeeds)
 	partialByte := append(protowire.AppendVarint(nil, uint64(len(blockBytes))), blockBytes[len(blockBytes)/2:]...)
 	blockfileMgr.currentFileWriter.append(partialByte, true)
 	checkBlockfilesInfoFromFS(t, blkStoreDir, blockfileMgr.blockfilesInfo)

--- a/common/ledger/blkstorage/blockfile_mgr.go
+++ b/common/ledger/blkstorage/blockfile_mgr.go
@@ -314,7 +314,7 @@ func (mgr *blockfileMgr) addBlockInternal(block *common.Block, syncToDisk bool) 
 			bcInfo.CurrentBlockHash, block.Header.PreviousHash,
 		)
 	}
-	blockBytes, info := serializeBlock(block)
+	blockBytes, info := serializeBlock(block, mgr.index.serializationNeeds())
 	blockHash := protoutil.BlockHeaderHash(block.Header)
 	// Get the location / offset where each transaction starts in the block and where the block ends
 	txOffsets := info.txOffsets

--- a/common/ledger/blkstorage/blockfile_mgr_test.go
+++ b/common/ledger/blkstorage/blockfile_mgr_test.go
@@ -397,7 +397,7 @@ func TestBlockfileMgrFileRolling(t *testing.T) {
 	blocks := testutil.ConstructTestBlocks(t, 200)
 	size := 0
 	for _, block := range blocks[:100] {
-		by, _ := serializeBlock(block)
+		by, _ := serializeBlock(block, allIndexNeeds)
 		blockBytesSize := len(by)
 		encodedLen := protowire.AppendVarint(nil, uint64(blockBytesSize))
 		size += blockBytesSize + len(encodedLen)
@@ -560,7 +560,7 @@ func TestBlockfileMgrNoSyncAndFlush(t *testing.T) {
 		blocks := testutil.ConstructTestBlocks(t, 20)
 		size := 0
 		for _, block := range blocks[:10] {
-			by, _ := serializeBlock(block)
+			by, _ := serializeBlock(block, allIndexNeeds)
 			blockBytesSize := len(by)
 			encodedLen := protowire.AppendVarint(nil, uint64(blockBytesSize))
 			size += blockBytesSize + len(encodedLen)

--- a/common/ledger/blkstorage/blockfile_scan_test.go
+++ b/common/ledger/blkstorage/blockfile_scan_test.go
@@ -39,7 +39,7 @@ func TestBlockFileScanSmallTxOnly(t *testing.T) {
 	require.Equal(t, len(blocks), numBlocks)
 	require.Equal(t, fileSize, endOffsetLastBlock)
 
-	expectedLastBlockBytes, _ := serializeBlock(blocks[len(blocks)-1])
+	expectedLastBlockBytes, _ := serializeBlock(blocks[len(blocks)-1], allIndexNeeds)
 	require.Equal(t, expectedLastBlockBytes, lastBlockBytes)
 }
 
@@ -70,6 +70,6 @@ func TestBlockFileScanSmallTxLastTxIncomplete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(blocks)-1, numBlocks)
 
-	expectedLastBlockBytes, _ := serializeBlock(blocks[len(blocks)-2])
+	expectedLastBlockBytes, _ := serializeBlock(blocks[len(blocks)-2], allIndexNeeds)
 	require.Equal(t, expectedLastBlockBytes, lastBlockBytes)
 }

--- a/common/ledger/blkstorage/blockindex.go
+++ b/common/ledger/blkstorage/blockindex.go
@@ -84,6 +84,16 @@ func (index *blockIndex) getLastBlockIndexed() (uint64, error) {
 	return decodeBlockNum(blockNumBytes), nil
 }
 
+// serializationNeeds reports what indexBlock below will read out of a serialized block, so
+// that serializeBlock can skip producing the rest. Keep it in step with indexBlock.
+func (index *blockIndex) serializationNeeds() indexNeeds {
+	txIDs := index.isAttributeIndexed(IndexableAttrTxID)
+	return indexNeeds{
+		txOffsets: txIDs || index.isAttributeIndexed(IndexableAttrBlockNumTranNum),
+		txIDs:     txIDs,
+	}
+}
+
 func (index *blockIndex) indexBlock(blockIdxInfo *blockIdxInfo, sync bool) error {
 	// do not index anything
 	if len(index.indexItemsMap) == 0 {
@@ -136,7 +146,9 @@ func (index *blockIndex) indexBlock(blockIdxInfo *blockIdxInfo, sync bool) error
 	if index.isAttributeIndexed(IndexableAttrBlockNumTranNum) {
 		for i, txoffset := range txOffsets {
 			txFlp := newFileLocationPointer(flp.fileSuffixNum, flp.offset, txoffset.loc)
-			logger.Debugf("Adding txLoc [%s] for tx number:[%d] ID: [%s] to blockNumTranNum index", txFlp, i, txoffset.txID)
+			// The txID is deliberately not logged here: it is only extracted when the txID
+			// index is configured, so it would print empty for a blockNumTranNum-only store.
+			logger.Debugf("Adding txLoc [%s] for tx number:[%d] to blockNumTranNum index", txFlp, i)
 			txFlpBytes := txFlp.marshal()
 			batch.Put(constructBlockNumTranNumKey(blkNum, uint64(i)), txFlpBytes)
 		}

--- a/common/ledger/blkstorage/reset_test.go
+++ b/common/ledger/blkstorage/reset_test.go
@@ -85,7 +85,7 @@ func TestResetBlockStore(t *testing.T) {
 	blocks1 := testutil.ConstructTestBlocks(t, 20) // 20 blocks persisted in ~5 block files
 	blocks2 := testutil.ConstructTestBlocks(t, 40) // 40 blocks persisted in ~5 block files
 
-	by, _ := serializeBlock(blocks1[0])
+	by, _ := serializeBlock(blocks1[0], allIndexNeeds)
 	maxFileSie := len(by) * 2
 
 	env := newTestEnv(t, NewConf(blockStoreRootDir, maxFileSie))
@@ -260,7 +260,7 @@ func assertRecordedHeight(t *testing.T, ledgerDir, expectedRecordedHt string) {
 func testutilEstimateTotalSizeOnDisk(t *testing.T, blocks []*common.Block) int {
 	size := 0
 	for _, block := range blocks {
-		by, _ := serializeBlock(block)
+		by, _ := serializeBlock(block, allIndexNeeds)
 		blockBytesSize := len(by)
 		encodedLen := protowire.AppendVarint(nil, uint64(blockBytesSize))
 		size += blockBytesSize + len(encodedLen)


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

- `serializeBlock` takes an `indexNeeds`, and `blockIndex.serializationNeeds` derives it from
  the configured attributes, so the decision lives next to `indexBlock`, which is the code that
  consumes the result. Neither the txIDs nor the offsets are produced unless an index reads them
  back.
- Split the offsets out into `constructTxIndexInfo`, which runs only when an index wants them.
  It derives each envelope's span from the envelope lengths rather than observing them mid-append
  (`protowire.AppendBytes` writes a length prefix plus the payload, so `protowire.SizeBytes`
  gives the same value the old `len(buf) - offset` did), and takes one backing array each for the
  infos and their locations instead of two allocations per transaction.
- Pre-allocate the serialization buffer to `serializedBlockSize(block)`, the exact length the
  writers produce, instead of growing it by append.
- Rename `addHeaderBytes` / `addMetadataBytes` to `appendHeaderBytes` / `appendMetadataBytes` and
  put the buffer first, matching the `protowire.Append*` shape. This diverges from upstream
  Fabric's names.
- Drop the txID from the blockNum-tranNum `Debugf` in `indexBlock`: it is only extracted when the
  txID index is configured, so it would print empty for a store that indexes by block number.
- Add `TestSerializeBlockIndexNeeds` (the serialized bytes are identical for every combination,
  and what was not asked for is absent), `TestBlockIndexSerializationNeeds` (a table over the
  attribute combinations), `TestSerializedBlockSizeIsExact`, and `BenchmarkSerializeBlock` /
  `BenchmarkSerializedBlockSize`.

#### Additional details (Optional)

The txID is the expensive half: `GetOrComputeTxIDFromEnvelope` unmarshals the whole envelope and
its payload header per transaction. On a 19-machine committer cluster driving 10,000-transaction
blocks, a CPU profile of the sidecar put block serialization (then
`addDataBytesAndConstructTxIndexInfo`, now inlined into `serializeBlock`) at 7.4% of the whole
process and about 88% of `appendBlock`, of which more than half was that unmarshal. Because the
append is one serialized goroutine, that was the pipeline's ceiling: the stage ran at a 100% duty
cycle on a machine sitting at 18% CPU with its disk 4% busy.

A store configured with neither index -- which is what a Fabric-X committer sidecar with
`disable-tx-id-index` set is, since it indexes by block number alone -- paid for all of it and
read none of it.

Measured on a 10,000-transaction block of 300-byte transactions, serialization with no tx index
goes from 8.7 ms and 21.1 MB allocated to 1.0 ms and 3.9 MB; with all indexes, from 25.9 ms to
14.9 ms. Roughly half of that is skipping the work and half is the pre-allocation: buffer growth
reallocates about 34 times per block and copies the whole buffer each time, whereas the size pass
is 14 us and zero allocations on the same block.

Verified: `make lint` reports 0 issues and `go test ./common/ledger/blkstorage/...` passes. The
strongest check on the computed offsets is the pre-existing `require.Equal(info, infoFromBB)` in
`testSerializedBlockInfo` -- `extractSerializedBlockInfo` re-derives the locations by parsing the
serialized bytes, so any drift in the spans fails it.

#### Related issues

- resolves #165
