### PR TITLE
Fxadmin require enough resp in submit

### DIFF
--- a/common/policies/bft.go
+++ b/common/policies/bft.go
@@ -58,3 +58,11 @@ func EncodeBFTBlockVerificationPolicy(consenterProtos []*cb.Consenter, ordererGr
 func ComputeBFTQuorum(totalNodes, faultyNodes int) int {
 	return int(math.Ceil(float64(totalNodes+faultyNodes+1) / 2))
 }
+
+// ComputeFTQ computes the F, Threshold and Quorum corresponds to N.
+func ComputeFTQ(n uint16) (f, threshold, quorum uint16) {
+	f = (n - 1) / 3
+	threshold = f + 1
+	quorum = uint16(math.Ceil((float64(n) + float64(f) + 1) / 2.0))
+	return f, threshold, quorum
+}

--- a/common/policies/bft.go
+++ b/common/policies/bft.go
@@ -58,11 +58,3 @@ func EncodeBFTBlockVerificationPolicy(consenterProtos []*cb.Consenter, ordererGr
 func ComputeBFTQuorum(totalNodes, faultyNodes int) int {
 	return int(math.Ceil(float64(totalNodes+faultyNodes+1) / 2))
 }
-
-// ComputeFTQ computes the F, Threshold and Quorum corresponds to N.
-func ComputeFTQ(n uint16) (f, threshold, quorum uint16) {
-	f = (n - 1) / 3
-	threshold = f + 1
-	quorum = uint16(math.Ceil((float64(n) + float64(f) + 1) / 2.0))
-	return f, threshold, quorum
-}

--- a/tools/fxadmin/core/client/client.go
+++ b/tools/fxadmin/core/client/client.go
@@ -135,6 +135,12 @@ func (c *Client) ChannelID() string {
 	return c.ordererConnInfo.ChannelID
 }
 
+// NumParties returns the number of parties in the network the client targets,
+// as read from the config block's ARMA shared config.
+func (c *Client) NumParties() int {
+	return c.ordererConnInfo.NumParties
+}
+
 // AssemblerEndpoints returns the assembler endpoints the client targets, in
 // config-block order.
 func (c *Client) AssemblerEndpoints() []string {

--- a/tools/fxadmin/core/client/client.go
+++ b/tools/fxadmin/core/client/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-common/common/util"
@@ -161,7 +162,7 @@ func (c *Client) FetchBlock(seek *ab.SeekInfo) (*cb.Block, error) {
 
 	var errs []error
 	for _, endpoint := range c.ordererConnInfo.AssemblerEndpoints {
-		block, err := c.fetchBlockFromEndpoint(endpoint, envelope)
+		block, err := c.fetchBlockFromEndpoint(context.Background(), endpoint, envelope)
 		if err == nil {
 			return block, nil
 		}
@@ -182,13 +183,14 @@ type LedgerStatus struct {
 // assembler's newest block (whose number is the ledger's last block), follows its
 // last-config index to the config block, and reads that block's sequence. Unlike
 // FetchBlock, it targets one endpoint and does not fail over, so callers (e.g.
-// `fxadmin follow`) can track each assembler's ledger independently.
-func (c *Client) FetchLedgerStatus(endpoint string) (LedgerStatus, error) {
+// `fxadmin follow`) can track each assembler's ledger independently. ctx bounds
+// the whole operation, including both underlying block fetches.
+func (c *Client) FetchLedgerStatus(ctx context.Context, endpoint string) (LedgerStatus, error) {
 	newestEnvelope, err := c.createSignedDeliverSeekEnvelope(seek.Newest())
 	if err != nil {
 		return LedgerStatus{}, err
 	}
-	newest, err := c.fetchBlockFromEndpoint(endpoint, newestEnvelope)
+	newest, err := c.fetchBlockFromEndpoint(ctx, endpoint, newestEnvelope)
 	if err != nil {
 		return LedgerStatus{}, err
 	}
@@ -206,7 +208,7 @@ func (c *Client) FetchLedgerStatus(endpoint string) (LedgerStatus, error) {
 		if err != nil {
 			return LedgerStatus{}, err
 		}
-		if configBlock, err = c.fetchBlockFromEndpoint(endpoint, configEnvelope); err != nil {
+		if configBlock, err = c.fetchBlockFromEndpoint(ctx, endpoint, configEnvelope); err != nil {
 			return LedgerStatus{}, err
 		}
 	}
@@ -266,16 +268,38 @@ func (c *Client) createSignedDeliverSeekEnvelope(seek *ab.SeekInfo) (*cb.Envelop
 	return envelope, nil
 }
 
+// dial opens a gRPC connection to endpoint, bounded by both ctx and the
+// configured DialTimeout, so a caller's deadline is honored while a single dial
+// is still capped. It mirrors comm.ClientConfig.Dial but derives its context
+// from ctx instead of context.Background().
+func (c *Client) dial(ctx context.Context, endpoint string) (*grpc.ClientConn, error) {
+	dialOpts, err := c.clientConfig.DialOptions()
+	if err != nil {
+		return nil, err
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, c.clientConfig.DialTimeout)
+	defer cancel()
+	//nolint:staticcheck // grpc.DialContext mirrors comm.ClientConfig.Dial.
+	conn, err := grpc.DialContext(dialCtx, endpoint, dialOpts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create new connection")
+	}
+	return conn, nil
+}
+
 // fetchBlockFromEndpoint opens a Deliver stream to endpoint, sends the seek envelope, and
-// receives exactly one block.
-func (c *Client) fetchBlockFromEndpoint(endpoint string, envelope *cb.Envelope) (*cb.Block, error) {
-	conn, err := c.clientConfig.Dial(endpoint)
+// receives exactly one block. ctx bounds both the dial and the RPC (capped by
+// rpcTimeout).
+func (c *Client) fetchBlockFromEndpoint(
+	ctx context.Context, endpoint string, envelope *cb.Envelope,
+) (*cb.Block, error) {
+	conn, err := c.dial(ctx, endpoint)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to dial assembler %s", endpoint)
 	}
 	defer func() { _ = conn.Close() }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 
 	stream, err := ab.NewAtomicBroadcastClient(conn).Deliver(ctx)

--- a/tools/fxadmin/core/client/client_test.go
+++ b/tools/fxadmin/core/client/client_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package client
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -227,7 +228,7 @@ func TestFetchLedgerStatus(t *testing.T) {
 		clientConfig:    comm.ClientConfig{DialTimeout: 5 * time.Second},
 	}
 
-	ledger, err := c.FetchLedgerStatus(endpoint)
+	ledger, err := c.FetchLedgerStatus(context.Background(), endpoint)
 	require.NoError(t, err)
 	require.Equal(t, uint64(104), ledger.LastBlockNumber)
 	require.Equal(t, uint64(5), ledger.LastConfigSequence)
@@ -243,8 +244,31 @@ func TestFetchLedgerStatusUnreachable(t *testing.T) {
 		clientConfig:    comm.ClientConfig{DialTimeout: 2 * time.Second},
 	}
 
-	_, err := c.FetchLedgerStatus(test.FreeAddress(t))
+	_, err := c.FetchLedgerStatus(context.Background(), test.FreeAddress(t))
 	require.Error(t, err)
+}
+
+// TestFetchLedgerStatusHonorsContextDeadline asserts that the context deadline
+// bounds the call: against an address whose TCP connect hangs, the call returns
+// when the (short) context deadline elapses rather than blocking for the much
+// larger dial timeout.
+func TestFetchLedgerStatusHonorsContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{
+		ordererConnInfo: &ordererconn.Info{},
+		// A large dial timeout: if the context were ignored, the call would block
+		// for this long instead of the context deadline below.
+		clientConfig: comm.ClientConfig{DialTimeout: time.Minute},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := c.FetchLedgerStatus(ctx, "203.0.113.1:7051")
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 10*time.Second)
 }
 
 func TestNewClientConfig(t *testing.T) {

--- a/tools/fxadmin/core/follow/follow.go
+++ b/tools/fxadmin/core/follow/follow.go
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 package follow
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -123,10 +124,15 @@ func pollAll(cl *client.Client, endpoints []string, expectedSequence uint64, tim
 
 // pollAssembler polls one assembler's last config sequence until it reaches
 // expected, or the deadline passes, returning the last sequence it observed.
+// Each query is bounded by the remaining time until deadline, so a hung
+// assembler cannot block past the command's timeout, and the sleep between polls
+// is capped to the remaining time.
 func pollAssembler(cl *client.Client, endpoint string, expected uint64, deadline time.Time) assemblerResult {
 	result := assemblerResult{endpoint: endpoint}
 	for {
-		ledger, err := cl.FetchLedgerStatus(endpoint)
+		ctx, cancel := context.WithDeadline(context.Background(), deadline)
+		ledger, err := cl.FetchLedgerStatus(ctx, endpoint)
+		cancel()
 		if err != nil {
 			logger.Debugf("follow: assembler %s: %v", endpoint, err)
 		} else {
@@ -138,10 +144,11 @@ func pollAssembler(cl *client.Client, endpoint string, expected uint64, deadline
 			}
 		}
 
-		if time.Now().After(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
 			return result
 		}
-		time.Sleep(pollInterval)
+		time.Sleep(min(pollInterval, remaining))
 	}
 }
 

--- a/tools/fxadmin/core/follow/follow_test.go
+++ b/tools/fxadmin/core/follow/follow_test.go
@@ -64,7 +64,7 @@ func TestRunTimeoutSomeBehind(t *testing.T) {
 	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
 
 	out := captureStdout(t, func() {
-		require.NoError(t, follow.New().Run(configPath, blockPath, time.Nanosecond))
+		require.NoError(t, follow.New().Run(configPath, blockPath, 500*time.Millisecond))
 	})
 
 	require.Equal(t, 2, strings.Count(out, "committed"))
@@ -82,7 +82,7 @@ func TestRunAssemblerUnreachable(t *testing.T) {
 	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
 
 	out := captureStdout(t, func() {
-		require.NoError(t, follow.New().Run(configPath, blockPath, time.Nanosecond))
+		require.NoError(t, follow.New().Run(configPath, blockPath, 500*time.Millisecond))
 	})
 
 	require.Equal(t, 1, strings.Count(out, "committed"))

--- a/tools/fxadmin/core/ordererconn/ordererconn.go
+++ b/tools/fxadmin/core/ordererconn/ordererconn.go
@@ -25,11 +25,12 @@ import (
 )
 
 // Info holds everything needed to dial the orderer, extracted from a config
-// block: the channel ID, the ordered router and assembler endpoints, and the
-// aggregated TLS CA certificates used to verify the orderer nodes' server
-// certificates.
+// block: the channel ID, the number of parties, the ordered router and
+// assembler endpoints, and the aggregated TLS CA certificates used to verify
+// the orderer nodes' server certificates.
 type Info struct {
 	ChannelID          string
+	NumParties         int // number of parties in the ARMA shared config
 	RouterEndpoints    []string
 	AssemblerEndpoints []string
 	TLSCACerts         [][]byte // TLS CA certificates of orderer organizations
@@ -79,7 +80,7 @@ func unmarshalSharedConfig(metadata []byte) (*ordererpb.SharedConfig, error) {
 // TLS CA certificates from an ARMA shared config into an Info for the given
 // channel.
 func infoFromSharedConfig(channelID string, shared *ordererpb.SharedConfig) (*Info, error) {
-	info := &Info{ChannelID: channelID}
+	info := &Info{ChannelID: channelID, NumParties: len(shared.GetPartiesConfig())}
 	for _, party := range shared.GetPartiesConfig() {
 		if router := party.GetRouterConfig(); router != nil {
 			info.RouterEndpoints = append(info.RouterEndpoints,

--- a/tools/fxadmin/core/ordererconn/ordererconn_test.go
+++ b/tools/fxadmin/core/ordererconn/ordererconn_test.go
@@ -50,6 +50,7 @@ func TestLoad(t *testing.T) {
 		info, err := ordererconn.Load(block, factory.GetDefault())
 		require.NoError(t, err)
 		require.Equal(t, armaChannel, info.ChannelID)
+		require.Equal(t, 2, info.NumParties)
 		require.Equal(t, []string{"router1.example.com:8013", "router2.example.com:8014"}, info.RouterEndpoints)
 		require.Equal(t,
 			[]string{"assembler1.example.com:8011", "assembler2.example.com:8012"},

--- a/tools/fxadmin/core/tx/tx.go
+++ b/tools/fxadmin/core/tx/tx.go
@@ -19,6 +19,7 @@ import (
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/hyperledger/fabric-x-common/common/policies"
 	"github.com/hyperledger/fabric-x-common/common/util"
 	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-common/protoutil"
@@ -228,13 +229,12 @@ func (*Handler) Prepare(inputPath, configPath, outputPath string) error {
 // transaction (a common.Envelope) at inputPath and broadcasts it to every
 // router of the network described by the config block at currentBlockPath,
 // using the client identity in the configuration YAML at configPath to sign the
-// connection. It collects the routers' acknowledgements and logs how many
-// routers acknowledged the transaction.
+// connection. It logs each router's outcome and a summary.
 //
-// Submit does not fail on individual router rejections or unreachable routers,
-// including the case where zero routers acknowledged the transaction: each
-// router's outcome is reported by reportBroadcast, and it returns an error only
-// when the broadcast could not be attempted at all (no routers configured).
+// Submit succeeds only when a BFT quorum of the routers acknowledged the
+// transaction: with n parties (one router each) the quorum is 2f+1, computed by
+// policies.ComputeFTQ(n) where n is the number of parties given from the config block.
+// Otherwise, it returns an error, so a partial or failed delivery is reported to the caller.
 func (h *Handler) Submit(inputPath, configPath, currentBlockPath string) error {
 	logger.Debugf("tx submit: input=%s config=%s current-block=%s", inputPath, configPath, currentBlockPath)
 
@@ -252,8 +252,10 @@ func (h *Handler) Submit(inputPath, configPath, currentBlockPath string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to broadcast configuration transaction")
 	}
-	reportBroadcast(statuses)
-	return nil
+
+	//nolint:gosec // number of parties is small and non-negative.
+	_, _, quorum := policies.ComputeFTQ(uint16(cl.NumParties()))
+	return reportBroadcast(statuses, int(quorum))
 }
 
 // readEnvelope reads and unmarshals a prepared configuration transaction
@@ -270,16 +272,28 @@ func readEnvelope(path string) (*cb.Envelope, error) {
 	return envelope, nil
 }
 
-// reportBroadcast logs how many routers acknowledged the transaction, listing
-// first the routers that rejected it or were unreachable.
-func reportBroadcast(statuses []client.RouterStatus) {
+// reportBroadcast logs each router's outcome, then a summary of how
+// many routers acknowledged the transaction against the required quorum. It
+// returns an error when fewer than quorum routers acknowledged, so submission
+// fails on a partial or failed delivery.
+func reportBroadcast(statuses []client.RouterStatus, quorum int) error {
 	for _, status := range statuses {
 		if status.Err != nil {
-			logger.Warnf("router %s failed to acknowledge: %v", status.Endpoint, status.Err)
+			logger.Warnf("router %s did not acknowledge the configuration transaction: %v",
+				status.Endpoint, status.Err)
+		} else {
+			logger.Infof("router %s acknowledged the configuration transaction", status.Endpoint)
 		}
 	}
-	logger.Infof("configuration transaction acknowledged by %d of %d routers",
-		countAcks(statuses), len(statuses))
+
+	acked := countAcks(statuses)
+	if acked < quorum {
+		return errors.Newf("configuration transaction acknowledged by %d of %d routers, below the quorum of %d",
+			acked, len(statuses), quorum)
+	}
+	logger.Infof("configuration transaction acknowledged by %d of %d routers, quorum of %d reached",
+		acked, len(statuses), quorum)
+	return nil
 }
 
 // countAcks returns the number of routers that acknowledged the transaction,

--- a/tools/fxadmin/core/tx/tx.go
+++ b/tools/fxadmin/core/tx/tx.go
@@ -252,9 +252,8 @@ func (h *Handler) Submit(inputPath, configPath, currentBlockPath string) error {
 		return errors.Wrap(err, "failed to broadcast configuration transaction")
 	}
 
-	//nolint:gosec // number of parties is small and non-negative.
 	f := (cl.NumParties() - 1) / 3
-	return reportBroadcast(statuses, 2*int(f)+1)
+	return reportBroadcast(statuses, 2*f+1)
 }
 
 // readEnvelope reads and unmarshals a prepared configuration transaction

--- a/tools/fxadmin/core/tx/tx.go
+++ b/tools/fxadmin/core/tx/tx.go
@@ -19,7 +19,6 @@ import (
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/hyperledger/fabric-x-common/common/policies"
 	"github.com/hyperledger/fabric-x-common/common/util"
 	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-common/protoutil"
@@ -231,10 +230,10 @@ func (*Handler) Prepare(inputPath, configPath, outputPath string) error {
 // using the client identity in the configuration YAML at configPath to sign the
 // connection. It logs each router's outcome and a summary.
 //
-// Submit succeeds only when a BFT quorum of the routers acknowledged the
-// transaction: with n parties (one router each) the quorum is 2f+1, computed by
-// policies.ComputeFTQ(n) where n is the number of parties given from the config block.
-// Otherwise, it returns an error, so a partial or failed delivery is reported to the caller.
+// Submit succeeds only when at least 2f+1 of the routers acknowledged the transaction,
+// where f is the number of faulty parties the network tolerates, derived from
+// the number of parties in the config block. Otherwise, it returns an error,
+// so a partial or failed delivery is reported to the caller.
 func (h *Handler) Submit(inputPath, configPath, currentBlockPath string) error {
 	logger.Debugf("tx submit: input=%s config=%s current-block=%s", inputPath, configPath, currentBlockPath)
 
@@ -254,8 +253,8 @@ func (h *Handler) Submit(inputPath, configPath, currentBlockPath string) error {
 	}
 
 	//nolint:gosec // number of parties is small and non-negative.
-	_, _, quorum := policies.ComputeFTQ(uint16(cl.NumParties()))
-	return reportBroadcast(statuses, int(quorum))
+	f := (cl.NumParties() - 1) / 3
+	return reportBroadcast(statuses, 2*int(f)+1)
 }
 
 // readEnvelope reads and unmarshals a prepared configuration transaction

--- a/tools/fxadmin/core/tx/tx_test.go
+++ b/tools/fxadmin/core/tx/tx_test.go
@@ -35,6 +35,7 @@ import (
 const (
 	adminYAML        = "admin.yaml"
 	missingInputCase = "missing input file"
+	localhost        = "localhost"
 
 	missingConfigCase   = "missing config file"
 	notEnvelopeCase     = "input is not an envelope"
@@ -60,7 +61,8 @@ func TestSendWritesPreparedTx(t *testing.T) {
 
 	// The broadcast fails because the generated block has no router endpoints,
 	// but the prepared transaction must still have been written for the record.
-	require.ErrorContains(t, tx.New().Send(endorsedPath, client.configPath, client.blockPath, outputPath), "no router endpoints")
+	err := tx.New().Send(endorsedPath, client.configPath, client.blockPath, outputPath)
+	require.ErrorContains(t, err, "no router endpoints")
 
 	out, err := os.ReadFile(outputPath)
 	require.NoError(t, err)
@@ -196,25 +198,42 @@ func TestSubmitErrors(t *testing.T) {
 	}
 }
 
-// TestSubmit asserts that `tx submit` reads the prepared configuration
-// transaction, connects to the network described by the config block, and
-// broadcasts the transaction to every router without error, including when some
-// routers reject it or are unreachable (the command reports per-router outcomes
-// but only fails when no routers are configured).
+// TestSubmit asserts that `tx submit` succeeds when a BFT quorum of the routers
+// acknowledged the transaction, even if some routers reject it or are
+// unreachable. With 4 parties the quorum is 2f+1 = 3, so 3 acknowledgements are
+// enough despite the 4th router being unreachable.
 func TestSubmit(t *testing.T) {
 	t.Parallel()
 
-	// Three routers: one acknowledges, one rejects, one is unreachable. Submit
-	// still returns nil, because it broadcasts to every router and reports the
-	// per-router outcomes rather than failing on individual rejections.
-	acking := test.StartBroadcastServer(t, cb.Status_SUCCESS)
-	rejecting := test.StartBroadcastServer(t, cb.Status_BAD_REQUEST)
-	unreachable := test.FreeAddress(t)
-
-	blockPath, configPath := newSubmitInputs(t, "test-channel", []string{acking, rejecting, unreachable})
+	endpoints := []string{
+		test.StartBroadcastServer(t, cb.Status_SUCCESS),
+		test.StartBroadcastServer(t, cb.Status_SUCCESS),
+		test.StartBroadcastServer(t, cb.Status_SUCCESS),
+		test.FreeAddress(t), // unreachable, but a quorum of 3 already acknowledged
+	}
+	blockPath, configPath := newSubmitInputs(t, "test-channel", endpoints)
 	txPath := writeFile(t, marshalConfigTx(t, "test-channel"))
 
 	require.NoError(t, tx.New().Submit(txPath, configPath, blockPath))
+}
+
+// TestSubmitBelowQuorum asserts that `tx submit` fails when fewer than a BFT
+// quorum of the routers acknowledged the transaction. With 4 parties the quorum
+// is 3, so 2 acknowledgements (one router rejects, one is unreachable) fall short.
+func TestSubmitBelowQuorum(t *testing.T) {
+	t.Parallel()
+
+	endpoints := []string{
+		test.StartBroadcastServer(t, cb.Status_SUCCESS),
+		test.StartBroadcastServer(t, cb.Status_SUCCESS),
+		test.StartBroadcastServer(t, cb.Status_BAD_REQUEST),
+		test.FreeAddress(t),
+	}
+	blockPath, configPath := newSubmitInputs(t, "test-channel", endpoints)
+	txPath := writeFile(t, marshalConfigTx(t, "test-channel"))
+
+	err := tx.New().Submit(txPath, configPath, blockPath)
+	require.ErrorContains(t, err, "acknowledged by 2 of 4 routers, below the quorum of 3")
 }
 
 // TestSubmitNoRouters asserts that `tx submit` fails when the config block
@@ -556,8 +575,8 @@ func newAdminConfigs(t *testing.T, count int) []adminConfig {
 	for i := range count {
 		partyID := uint32(i + 1)
 		endpoints = append(endpoints,
-			&types.OrdererEndpoint{ID: partyID, Host: "localhost", Port: 7050 + 2*i, API: []string{types.Broadcast}},
-			&types.OrdererEndpoint{ID: partyID, Host: "localhost", Port: 7051 + 2*i, API: []string{types.Deliver}},
+			&types.OrdererEndpoint{ID: partyID, Host: localhost, Port: 7050 + 2*i, API: []string{types.Broadcast}},
+			&types.OrdererEndpoint{ID: partyID, Host: localhost, Port: 7051 + 2*i, API: []string{types.Deliver}},
 		)
 	}
 	block, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(targetPath, &testcrypto.ConfigBlock{
@@ -690,6 +709,15 @@ func newSubmitInputs(t *testing.T, channelID string, routerEndpoints []string) (
 			AssemblerConfig: &ordererpb.AssemblerNodeConfig{Host: host, Port: port},
 		})
 	}
+	return writeSubmitInputs(t, channelID, shared)
+}
+
+// writeSubmitInputs builds a real ARMA config block carrying shared, writes it
+// to disk, and writes an admin configuration YAML for a loadable identity of the
+// same crypto tree. It returns the paths to the block and the admin configuration.
+func writeSubmitInputs(t *testing.T, channelID string, shared *ordererpb.SharedConfig) (blockPath, configPath string) {
+	t.Helper()
+
 	meta, err := proto.Marshal(shared)
 	require.NoError(t, err)
 
@@ -701,7 +729,7 @@ func newSubmitInputs(t *testing.T, channelID string, routerEndpoints []string) (
 		Organizations: []cryptogen.OrganizationParameters{{
 			Name:             "orderer-org-1",
 			Domain:           "orderer-org-1.com",
-			OrdererEndpoints: []*types.OrdererEndpoint{{ID: 1, Host: "localhost", Port: 7050}},
+			OrdererEndpoints: []*types.OrdererEndpoint{{ID: 1, Host: localhost, Port: 7050}},
 			ConsenterNodes:   []cryptogen.Node{{CommonName: "consenter", Hostname: "consenter"}},
 			OrdererNodes:     []cryptogen.Node{{CommonName: "orderer-node", Hostname: "orderer-node"}},
 		}},

--- a/tools/fxadmin/core/tx/tx_test.go
+++ b/tools/fxadmin/core/tx/tx_test.go
@@ -60,7 +60,7 @@ func TestSendWritesPreparedTx(t *testing.T) {
 
 	// The broadcast fails because the generated block has no router endpoints,
 	// but the prepared transaction must still have been written for the record.
-	require.Error(t, tx.New().Send(endorsedPath, client.configPath, client.blockPath, outputPath))
+	require.ErrorContains(t, tx.New().Send(endorsedPath, client.configPath, client.blockPath, outputPath), "no router endpoints")
 
 	out, err := os.ReadFile(outputPath)
 	require.NoError(t, err)
@@ -533,7 +533,7 @@ func TestPrepareErrors(t *testing.T) {
 
 // adminConfig is a generated admin identity: the path to its admin
 // configuration YAML plus the MSP directory and ID for independent verification,
-// and the path to the config block describing the network the admins connects to.
+// and the path to the config block describing the network the admins connect to.
 type adminConfig struct {
 	configPath, mspDir, mspID, blockPath string
 }


### PR DESCRIPTION
#### Type of change
New feature

#### Description
- fix comments from PR #160 
- Return an error if fewer than 2f+1 routers acknowledged the tx in the submit command.

#### Related issues
https://github.com/hyperledger/fabric-x-orderer/issues/1067