### PR TITLE
[fxadmin] follow returns the config block

### DIFF
--- a/tools/fxadmin/core/cli/cli.go
+++ b/tools/fxadmin/core/cli/cli.go
@@ -247,7 +247,10 @@ func (c *CLI) addFollowCommand() {
 		ExistingFile()
 	timeout := follow.Flag(flagTimeout, "How long to pull blocks from the assemblers before reporting results.").
 		Required().Duration()
+	output := follow.
+		Flag(flagOutput, "Path to write the agreed next config block to, for use as the next --current-block.").
+		Required().String()
 	c.register(follow, func() error {
-		return c.handlers.Follow.Run(*config, *currentBlock, *timeout)
+		return c.handlers.Follow.Run(*config, *currentBlock, *output, *timeout)
 	})
 }

--- a/tools/fxadmin/core/cli/cli_test.go
+++ b/tools/fxadmin/core/cli/cli_test.go
@@ -34,6 +34,7 @@ const (
 	fileEndorsement2 = "endorsed_config_update2.pb"
 	fileEndorsed     = "endorsed_config_update.pb"
 	fileConfigTx     = "config_tx.pb"
+	fileNextConfig   = "next_config.pb"
 )
 
 // call records the handler that was invoked and the values it received, so a
@@ -120,8 +121,8 @@ func (f fakeTx) Send(inputPath, configPath, currentBlockPath, outputPath string)
 
 type fakeFollow struct{ invoked *call }
 
-func (f fakeFollow) Run(configPath, currentBlockPath string, timeout time.Duration) error {
-	*f.invoked = call{handler: "Follow", args: []string{configPath, currentBlockPath}, timeout: timeout}
+func (f fakeFollow) Run(configPath, currentBlockPath, outputPath string, timeout time.Duration) error {
+	*f.invoked = call{handler: "Follow", args: []string{configPath, currentBlockPath, outputPath}, timeout: timeout}
 	return nil
 }
 
@@ -239,10 +240,13 @@ func TestRunRoutesToHandler(t *testing.T) {
 			wantArgs:    []string{endorsed, admin, currBlock, fileConfigTx},
 		},
 		{
-			name:        "follow",
-			args:        []string{cmdFollow, flagConfig, admin, flagCurrentBlock, currBlock, "--timeout", "30s"},
+			name: "follow",
+			args: []string{
+				cmdFollow, flagConfig, admin, flagCurrentBlock, currBlock,
+				"--timeout", "30s", flagOutput, fileNextConfig,
+			},
 			wantHandler: "Follow",
-			wantArgs:    []string{admin, currBlock},
+			wantArgs:    []string{admin, currBlock, fileNextConfig},
 			wantTimeout: 30 * time.Second,
 		},
 	} {
@@ -295,8 +299,11 @@ func TestParseErrors(t *testing.T) {
 			wantErr: "file",
 		},
 		{
-			name:    "bad duration for follow",
-			args:    []string{cmdFollow, flagConfig, admin, flagCurrentBlock, currBlock, "--timeout", "notaduration"},
+			name: "bad duration for follow",
+			args: []string{
+				cmdFollow, flagConfig, admin, flagCurrentBlock, currBlock,
+				"--timeout", "notaduration", flagOutput, fileNextConfig,
+			},
 			wantErr: "invalid duration",
 		},
 	} {

--- a/tools/fxadmin/core/cli/handlers.go
+++ b/tools/fxadmin/core/cli/handlers.go
@@ -47,7 +47,7 @@ type TxHandler interface {
 
 // FollowHandler executes `fxadmin follow`.
 type FollowHandler interface {
-	Run(configPath, currentBlockPath string, timeout time.Duration) error
+	Run(configPath, currentBlockPath, outputPath string, timeout time.Duration) error
 }
 
 // Handlers groups the per-command handlers the CLI dispatches to. It is

--- a/tools/fxadmin/core/client/client.go
+++ b/tools/fxadmin/core/client/client.go
@@ -109,6 +109,18 @@ func ReadConfigBlock(path string) (*cb.Block, error) {
 	return block, nil
 }
 
+// WriteBlock marshals block and writes it to path.
+func WriteBlock(block *cb.Block, path string) error {
+	content, err := proto.Marshal(block)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal block")
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		return errors.Wrapf(err, "failed to write block to %q", path)
+	}
+	return nil
+}
+
 // SequenceFromBlock returns the config sequence recorded in a config block's
 // configuration envelope. It reads the sequence field directly rather than
 // building a channel config bundle, so it needs no BCCSP.

--- a/tools/fxadmin/core/client/client.go
+++ b/tools/fxadmin/core/client/client.go
@@ -154,6 +154,12 @@ func (c *Client) NumParties() int {
 	return c.ordererConnInfo.NumParties
 }
 
+// FaultThreshold returns f, the number of faulty parties the network tolerates,
+// derived from the number of parties: f = (n-1)/3.
+func (c *Client) FaultThreshold() int {
+	return (c.ordererConnInfo.NumParties - 1) / 3
+}
+
 // AssemblerEndpoints returns the assembler endpoints the client targets, in
 // config-block order.
 func (c *Client) AssemblerEndpoints() []string {

--- a/tools/fxadmin/core/client/client.go
+++ b/tools/fxadmin/core/client/client.go
@@ -173,10 +173,12 @@ func (c *Client) FetchBlock(seek *ab.SeekInfo) (*cb.Block, error) {
 }
 
 // LedgerStatus summarizes a single assembler's ledger: the number of its newest
-// block (its height indicator) and the config sequence of its last config block.
+// block (its height indicator), the config sequence of its last config block,
+// and the last config block itself.
 type LedgerStatus struct {
 	LastBlockNumber    uint64
 	LastConfigSequence uint64
+	ConfigBlock        *cb.Block
 }
 
 // FetchLedgerStatus returns the ledger status of a single assembler. It seeks the
@@ -217,7 +219,7 @@ func (c *Client) FetchLedgerStatus(ctx context.Context, endpoint string) (Ledger
 	if err != nil {
 		return LedgerStatus{}, err
 	}
-	return LedgerStatus{LastBlockNumber: lastBlock, LastConfigSequence: sequence}, nil
+	return LedgerStatus{LastBlockNumber: lastBlock, LastConfigSequence: sequence, ConfigBlock: configBlock}, nil
 }
 
 // RouterStatus is the outcome of broadcasting an envelope to a single router.

--- a/tools/fxadmin/core/follow/follow.go
+++ b/tools/fxadmin/core/follow/follow.go
@@ -92,8 +92,8 @@ func (h *Handler) Run(configPath, currentBlockPath, outputPath string, timeout t
 	}
 	_, _ = fmt.Print(formatSummary(results, expected, timeout))
 
-	quorum := faultThreshold(cl.NumParties()) + 1
-	agreed, count := agreedConfigBlock(results, expected)
+	quorum := cl.FaultThreshold() + 1
+	agreed, count := agreedConfigBlock(results, expected, quorum)
 	if agreed == nil {
 		return errors.Newf("no config block at last config sequence %d was agreed by a quorum of %d assemblers",
 			expected, quorum)
@@ -106,19 +106,12 @@ func (h *Handler) Run(configPath, currentBlockPath, outputPath string, timeout t
 	return nil
 }
 
-// faultThreshold returns f, the number of faulty parties a BFT network of n
-// parties tolerates.
-func faultThreshold(n int) int {
-	return (n - 1) / 3
-}
-
-// agreedConfigBlock returns the config block at the expected sequence that f+1
-// of assemblers reported identically, along with the number of
-// assemblers that reported it. It returns nil when no block reaches f+1 copies.
-// Blocks are compared by their header hash, which commits to the block number,
-// previous hash, and data hash.
-func agreedConfigBlock(results []assemblerResult, expected uint64) (*cb.Block, int) {
-	quorum := faultThreshold(len(results)) + 1
+// agreedConfigBlock returns the config block at the expected sequence that a
+// quorum of assemblers reported identically, along with the number of
+// assemblers that reported it. It returns nil when no block reaches quorum
+// copies. Blocks are compared by their header hash, which commits to the block
+// number, previous hash, and data hash.
+func agreedConfigBlock(results []assemblerResult, expected uint64, quorum int) (*cb.Block, int) {
 	counts := make(map[string]int)
 	blocks := make(map[string]*cb.Block)
 	for _, result := range results {

--- a/tools/fxadmin/core/follow/follow.go
+++ b/tools/fxadmin/core/follow/follow.go
@@ -11,7 +11,6 @@ package follow
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -22,7 +21,6 @@ import (
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/client"
@@ -100,7 +98,7 @@ func (h *Handler) Run(configPath, currentBlockPath, outputPath string, timeout t
 		return errors.Newf("no config block at last config sequence %d was agreed by a quorum of %d assemblers",
 			expected, quorum)
 	}
-	if err := writeBlock(agreed, outputPath); err != nil {
+	if err := client.WriteBlock(agreed, outputPath); err != nil {
 		return err
 	}
 	logger.Infof("config block at last config sequence %d agreed by %d assemblers (quorum %d), written to %s",
@@ -135,18 +133,6 @@ func agreedConfigBlock(results []assemblerResult, expected uint64) (*cb.Block, i
 		}
 	}
 	return nil, 0
-}
-
-// writeBlock marshals block and writes it to path.
-func writeBlock(block *cb.Block, path string) error {
-	content, err := proto.Marshal(block)
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal agreed config block")
-	}
-	if err := os.WriteFile(path, content, 0o600); err != nil {
-		return errors.Wrapf(err, "failed to write config block to %q", path)
-	}
-	return nil
 }
 
 // notCommitted returns how many assemblers had not committed a block at the

--- a/tools/fxadmin/core/follow/follow.go
+++ b/tools/fxadmin/core/follow/follow.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"google.golang.org/protobuf/proto"
 
-	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/client"
 )
 
@@ -109,8 +109,7 @@ func (h *Handler) Run(configPath, currentBlockPath, outputPath string, timeout t
 // agreedConfigBlock returns the config block at the expected sequence that a
 // quorum of assemblers reported identically, along with the number of
 // assemblers that reported it. It returns nil when no block reaches quorum
-// copies. Blocks are compared by their header hash, which commits to the block
-// number, previous hash, and data hash.
+// copies. Blocks are compared by their full marshaled bytes.
 func agreedConfigBlock(results []assemblerResult, expected uint64, quorum int) (*cb.Block, int) {
 	counts := make(map[string]int)
 	blocks := make(map[string]*cb.Block)
@@ -118,7 +117,12 @@ func agreedConfigBlock(results []assemblerResult, expected uint64, quorum int) (
 		if !result.ok || result.lastConfigSequence != expected || result.configBlock == nil {
 			continue
 		}
-		key := string(protoutil.BlockHeaderHash(result.configBlock.GetHeader()))
+		marshaled, err := proto.Marshal(result.configBlock)
+		if err != nil {
+			logger.Debugf("follow: skipping unmarshalable config block from %s: %v", result.endpoint, err)
+			continue
+		}
+		key := string(marshaled)
 		counts[key]++
 		blocks[key] = result.configBlock
 		if counts[key] >= quorum {

--- a/tools/fxadmin/core/follow/follow.go
+++ b/tools/fxadmin/core/follow/follow.go
@@ -11,15 +11,20 @@ package follow
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"text/tabwriter"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"google.golang.org/protobuf/proto"
 
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/client"
 )
 
@@ -54,8 +59,16 @@ func New() *Handler {
 // elapses, and prints a per-assembler summary. A config update changes at most
 // one assembler, so the endpoints in the current block still reach the rest;
 // assemblers that cannot be reached are reported as unreachable.
-func (h *Handler) Run(configPath, currentBlockPath string, timeout time.Duration) error {
-	logger.Debugf("follow: config=%s current-block=%s timeout=%s", configPath, currentBlockPath, timeout)
+//
+// Once at least f+1 assemblers report the identical next config block (f being
+// the number of faulty parties the network tolerates), that block is trusted —
+// f+1 matching copies guarantee at least one came from an honest assembler — and
+// written to outputPath, ready to be the --current-block of the next
+// reconfiguration. Run returns an error if no such agreement is reached before
+// the timeout.
+func (h *Handler) Run(configPath, currentBlockPath, outputPath string, timeout time.Duration) error {
+	logger.Debugf("follow: config=%s current-block=%s output=%s timeout=%s",
+		configPath, currentBlockPath, outputPath, timeout)
 
 	block, err := client.ReadConfigBlock(currentBlockPath)
 	if err != nil {
@@ -80,6 +93,59 @@ func (h *Handler) Run(configPath, currentBlockPath string, timeout time.Duration
 			timeout, pending, len(results), expected)
 	}
 	_, _ = fmt.Print(formatSummary(results, expected, timeout))
+
+	quorum := faultThreshold(cl.NumParties()) + 1
+	agreed, count := agreedConfigBlock(results, expected)
+	if agreed == nil {
+		return errors.Newf("no config block at last config sequence %d was agreed by a quorum of %d assemblers",
+			expected, quorum)
+	}
+	if err := writeBlock(agreed, outputPath); err != nil {
+		return err
+	}
+	logger.Infof("config block at last config sequence %d agreed by %d assemblers (quorum %d), written to %s",
+		expected, count, quorum, outputPath)
+	return nil
+}
+
+// faultThreshold returns f, the number of faulty parties a BFT network of n
+// parties tolerates.
+func faultThreshold(n int) int {
+	return (n - 1) / 3
+}
+
+// agreedConfigBlock returns the config block at the expected sequence that f+1
+// of assemblers reported identically, along with the number of
+// assemblers that reported it. It returns nil when no block reaches f+1 copies.
+// Blocks are compared by their header hash, which commits to the block number,
+// previous hash, and data hash.
+func agreedConfigBlock(results []assemblerResult, expected uint64) (*cb.Block, int) {
+	quorum := faultThreshold(len(results)) + 1
+	counts := make(map[string]int)
+	blocks := make(map[string]*cb.Block)
+	for _, result := range results {
+		if !result.ok || result.lastConfigSequence != expected || result.configBlock == nil {
+			continue
+		}
+		key := string(protoutil.BlockHeaderHash(result.configBlock.GetHeader()))
+		counts[key]++
+		blocks[key] = result.configBlock
+		if counts[key] >= quorum {
+			return blocks[key], counts[key]
+		}
+	}
+	return nil, 0
+}
+
+// writeBlock marshals block and writes it to path.
+func writeBlock(block *cb.Block, path string) error {
+	content, err := proto.Marshal(block)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal agreed config block")
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		return errors.Wrapf(err, "failed to write config block to %q", path)
+	}
 	return nil
 }
 
@@ -96,12 +162,14 @@ func notCommitted(results []assemblerResult, expected uint64) int {
 }
 
 // assemblerResult is the ledger status observed at a single assembler: its last
-// block number (ledger height indicator) and last config sequence. ok is false
-// when the assembler never reported a status before the deadline.
+// block number (ledger height indicator), last config sequence, and last config
+// block. ok is false when the assembler never reported a status before the
+// deadline.
 type assemblerResult struct {
 	endpoint           string
 	lastBlockNumber    uint64
 	lastConfigSequence uint64
+	configBlock        *cb.Block
 	ok                 bool
 }
 
@@ -138,6 +206,7 @@ func pollAssembler(cl *client.Client, endpoint string, expected uint64, deadline
 		} else {
 			result.lastBlockNumber = ledger.LastBlockNumber
 			result.lastConfigSequence = ledger.LastConfigSequence
+			result.configBlock = ledger.ConfigBlock
 			result.ok = true
 			if ledger.LastConfigSequence >= expected {
 				return result

--- a/tools/fxadmin/core/follow/follow_internal_test.go
+++ b/tools/fxadmin/core/follow/follow_internal_test.go
@@ -11,7 +11,10 @@ import (
 	"testing"
 	"time"
 
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-common/protoutil"
 )
 
 // Endpoint addresses reused across the classification and summary tests.
@@ -92,4 +95,60 @@ func TestSummaryLine(t *testing.T) {
 	require.Equal(t,
 		"expected last config sequence: 5, 2 out of 4 assemblers committed a block with last config sequence 5",
 		line)
+}
+
+// TestAgreedConfigBlock asserts a block is returned only when the given quorum
+// of assemblers report the identical block (by header hash) at the expected
+// sequence.
+func TestAgreedConfigBlock(t *testing.T) {
+	t.Parallel()
+
+	// blockX and blockY are distinct blocks at the same sequence 5,
+	// as a divergent assembler would serve.
+	blockX := protoutil.NewBlock(5, []byte("x"))
+	blockY := protoutil.NewBlock(5, []byte("y"))
+	at := func(seq uint64, block *cb.Block) assemblerResult {
+		return assemblerResult{lastConfigSequence: seq, configBlock: block, ok: true}
+	}
+
+	t.Run("returns the block once a quorum reports it", func(t *testing.T) {
+		t.Parallel()
+		results := []assemblerResult{at(5, blockX), at(5, blockX), at(5, blockY)}
+		agreed, count := agreedConfigBlock(results, 5, 2)
+		require.NotNil(t, agreed)
+		require.Equal(t, 2, count)
+		require.Equal(t, protoutil.BlockHeaderHash(blockX.GetHeader()), protoutil.BlockHeaderHash(agreed.GetHeader()))
+	})
+
+	t.Run("nil when no block reaches the quorum", func(t *testing.T) {
+		t.Parallel()
+		// Three assemblers at sequence 5 but each on a different block: no block
+		// gathers 2 identical copies.
+		results := []assemblerResult{at(5, blockX), at(5, blockY), at(5, protoutil.NewBlock(5, []byte("z")))}
+		agreed, count := agreedConfigBlock(results, 5, 2)
+		require.Nil(t, agreed)
+		require.Zero(t, count)
+	})
+
+	t.Run("quorum derived from party count may exceed len(results)", func(t *testing.T) {
+		t.Parallel()
+		// Two reachable assemblers agree, but the network has more parties (quorum 3),
+		// so their agreement is not yet enough.
+		results := []assemblerResult{at(5, blockX), at(5, blockX)}
+		agreed, count := agreedConfigBlock(results, 5, 3)
+		require.Nil(t, agreed)
+		require.Zero(t, count)
+	})
+
+	t.Run("ignores results at the wrong sequence or without a block", func(t *testing.T) {
+		t.Parallel()
+		results := []assemblerResult{
+			at(4, blockX),                      // behind: wrong sequence
+			{lastConfigSequence: 5, ok: false}, // unreachable: no block
+			{lastConfigSequence: 5, ok: true},  // committed but nil block
+			at(5, blockX),
+		}
+		agreed, _ := agreedConfigBlock(results, 5, 2)
+		require.Nil(t, agreed) // only one valid copy of blockX
+	})
 }

--- a/tools/fxadmin/core/follow/follow_internal_test.go
+++ b/tools/fxadmin/core/follow/follow_internal_test.go
@@ -13,6 +13,7 @@ import (
 
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-common/protoutil"
 )
@@ -98,57 +99,72 @@ func TestSummaryLine(t *testing.T) {
 }
 
 // TestAgreedConfigBlock asserts a block is returned only when the given quorum
-// of assemblers report the identical block (by header hash) at the expected
+// of assemblers report the identical block (by full bytes) at the expected
 // sequence.
+//
+//nolint:paralleltest
 func TestAgreedConfigBlock(t *testing.T) {
-	t.Parallel()
-
 	// blockX and blockY are distinct blocks at the same sequence 5,
 	// as a divergent assembler would serve.
 	blockX := protoutil.NewBlock(5, []byte("x"))
 	blockY := protoutil.NewBlock(5, []byte("y"))
-	at := func(seq uint64, block *cb.Block) assemblerResult {
-		return assemblerResult{lastConfigSequence: seq, configBlock: block, ok: true}
-	}
 
 	t.Run("returns the block once a quorum reports it", func(t *testing.T) {
-		t.Parallel()
-		results := []assemblerResult{at(5, blockX), at(5, blockX), at(5, blockY)}
+		results := []assemblerResult{committedAt(5, blockX), committedAt(5, blockX), committedAt(5, blockY)}
 		agreed, count := agreedConfigBlock(results, 5, 2)
 		require.NotNil(t, agreed)
 		require.Equal(t, 2, count)
-		require.Equal(t, protoutil.BlockHeaderHash(blockX.GetHeader()), protoutil.BlockHeaderHash(agreed.GetHeader()))
+		require.True(t, proto.Equal(blockX, agreed))
+	})
+
+	t.Run("blocks differing only in metadata do not agree", func(t *testing.T) {
+		// Two blocks with identical headers and data but different metadata.
+		signedA := protoutil.NewBlock(5, []byte("h"))
+		signedA.Metadata = &cb.BlockMetadata{Metadata: [][]byte{[]byte("sig-A")}}
+		signedB := protoutil.NewBlock(5, []byte("h"))
+		signedB.Metadata = &cb.BlockMetadata{Metadata: [][]byte{[]byte("sig-B")}}
+		require.Equal(t, protoutil.BlockHeaderHash(signedA.GetHeader()), protoutil.BlockHeaderHash(signedB.GetHeader()),
+			"sanity: the two blocks share a header hash and differ only in metadata")
+
+		agreed, count := agreedConfigBlock([]assemblerResult{committedAt(5, signedA), committedAt(5, signedB)}, 5, 2)
+		require.Nil(t, agreed)
+		require.Zero(t, count)
 	})
 
 	t.Run("nil when no block reaches the quorum", func(t *testing.T) {
-		t.Parallel()
 		// Three assemblers at sequence 5 but each on a different block: no block
 		// gathers 2 identical copies.
-		results := []assemblerResult{at(5, blockX), at(5, blockY), at(5, protoutil.NewBlock(5, []byte("z")))}
+		results := []assemblerResult{
+			committedAt(5, blockX), committedAt(5, blockY), committedAt(5, protoutil.NewBlock(5, []byte("z"))),
+		}
 		agreed, count := agreedConfigBlock(results, 5, 2)
 		require.Nil(t, agreed)
 		require.Zero(t, count)
 	})
 
 	t.Run("quorum derived from party count may exceed len(results)", func(t *testing.T) {
-		t.Parallel()
 		// Two reachable assemblers agree, but the network has more parties (quorum 3),
 		// so their agreement is not yet enough.
-		results := []assemblerResult{at(5, blockX), at(5, blockX)}
+		results := []assemblerResult{committedAt(5, blockX), committedAt(5, blockX)}
 		agreed, count := agreedConfigBlock(results, 5, 3)
 		require.Nil(t, agreed)
 		require.Zero(t, count)
 	})
 
 	t.Run("ignores results at the wrong sequence or without a block", func(t *testing.T) {
-		t.Parallel()
 		results := []assemblerResult{
-			at(4, blockX),                      // behind: wrong sequence
+			committedAt(4, blockX),             // behind: wrong sequence
 			{lastConfigSequence: 5, ok: false}, // unreachable: no block
 			{lastConfigSequence: 5, ok: true},  // committed but nil block
-			at(5, blockX),
+			committedAt(5, blockX),
 		}
 		agreed, _ := agreedConfigBlock(results, 5, 2)
 		require.Nil(t, agreed) // only one valid copy of blockX
 	})
+}
+
+// committedAt returns an assemblerResult for an assembler that reported block at
+// the given last config sequence.
+func committedAt(sequence uint64, block *cb.Block) assemblerResult {
+	return assemblerResult{lastConfigSequence: sequence, configBlock: block, ok: true}
 }

--- a/tools/fxadmin/core/follow/follow_test.go
+++ b/tools/fxadmin/core/follow/follow_test.go
@@ -38,7 +38,9 @@ import (
 //
 //nolint:paralleltest
 func TestRunAllAssemblersCommitted(t *testing.T) {
-	endpoints := []string{serveAssembler(t, 1), serveAssembler(t, 1), serveAssembler(t, 1)}
+	endpoints := []string{
+		serveAssembler(t, 1), serveAssembler(t, 1), serveAssembler(t, 1), serveAssembler(t, 1),
+	}
 	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
 	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
 
@@ -47,9 +49,9 @@ func TestRunAllAssemblersCommitted(t *testing.T) {
 	})
 
 	require.Contains(t, out, "LAST BLOCK")
-	require.Equal(t, 3, strings.Count(out, "committed"))
+	require.Equal(t, 4, strings.Count(out, "committed"))
 	committedRows := regexp.MustCompile(`\s10\s+1\s+committed`).FindAllString(out, -1)
-	require.Len(t, committedRows, 3)
+	require.Len(t, committedRows, 4)
 	require.NotContains(t, out, "behind")
 	require.NotContains(t, out, "unreachable")
 
@@ -63,19 +65,21 @@ func TestRunAllAssemblersCommitted(t *testing.T) {
 //
 //nolint:paralleltest
 func TestRunTimeoutSomeBehind(t *testing.T) {
-	// Two assemblers already serve the new config sequence 1; one is still at the
-	// current sequence 0, so it never reaches the expected sequence.
-	endpoints := []string{serveAssembler(t, 1), serveAssembler(t, 1), serveAssembler(t, 0)}
+	// Three of four assemblers already serve the new config sequence 1; the fourth
+	// is still at the current sequence 0, so it never reaches the expected sequence.
+	endpoints := []string{
+		serveAssembler(t, 1), serveAssembler(t, 1), serveAssembler(t, 1), serveAssembler(t, 0),
+	}
 	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
 	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
 
-	// With 3 parties the quorum is f+1 = 1, so the two committed assemblers still
-	// agree on the next config block; it is written despite the third being behind.
+	// With 4 parties the quorum is f+1 = 2, so the three committed assemblers still
+	// agree on the next config block; it is written despite the fourth being behind.
 	out := captureStdout(t, func() {
 		require.NoError(t, follow.New().Run(configPath, blockPath, outputPath, 500*time.Millisecond))
 	})
 
-	require.Equal(t, 2, strings.Count(out, "committed"))
+	require.Equal(t, 3, strings.Count(out, "committed"))
 	require.Equal(t, 1, strings.Count(out, "behind"))
 	require.Equal(t, uint64(1), sequenceOfWrittenBlock(t, outputPath))
 }
@@ -85,20 +89,22 @@ func TestRunTimeoutSomeBehind(t *testing.T) {
 //
 //nolint:paralleltest
 func TestRunAssemblerUnreachable(t *testing.T) {
-	// One assembler serves the new config sequence 1; the other has no server
-	// listening, so it can never be reached.
-	endpoints := []string{serveAssembler(t, 1), clienttest.FreeAddress(t)}
+	// Two of four assemblers serve the new config sequence 1; the other two have no
+	// server listening, so they can never be reached.
+	endpoints := []string{
+		serveAssembler(t, 1), serveAssembler(t, 1), clienttest.FreeAddress(t), clienttest.FreeAddress(t),
+	}
 	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
 	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
 
-	// With 2 parties the quorum is f+1 = 1, so the one reachable committed
-	// assembler is enough to agree on and write the next config block.
+	// With 4 parties the quorum is f+1 = 2, so the two reachable committed
+	// assemblers are exactly enough to agree on and write the next config block.
 	out := captureStdout(t, func() {
 		require.NoError(t, follow.New().Run(configPath, blockPath, outputPath, 500*time.Millisecond))
 	})
 
-	require.Equal(t, 1, strings.Count(out, "committed"))
-	require.Equal(t, 1, strings.Count(out, "unreachable"))
+	require.Equal(t, 2, strings.Count(out, "committed"))
+	require.Equal(t, 2, strings.Count(out, "unreachable"))
 	require.Equal(t, uint64(1), sequenceOfWrittenBlock(t, outputPath))
 }
 

--- a/tools/fxadmin/core/follow/follow_test.go
+++ b/tools/fxadmin/core/follow/follow_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/api/types"
 	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
 	"github.com/hyperledger/fabric-x-common/tools/cryptogen"
+	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/client"
 	clienttest "github.com/hyperledger/fabric-x-common/tools/fxadmin/core/client/test"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/follow"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/user"
@@ -39,9 +40,10 @@ import (
 func TestRunAllAssemblersCommitted(t *testing.T) {
 	endpoints := []string{serveAssembler(t, 1), serveAssembler(t, 1), serveAssembler(t, 1)}
 	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
+	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
 
 	out := captureStdout(t, func() {
-		require.NoError(t, follow.New().Run(configPath, blockPath, 30*time.Second))
+		require.NoError(t, follow.New().Run(configPath, blockPath, outputPath, 30*time.Second))
 	})
 
 	require.Contains(t, out, "LAST BLOCK")
@@ -50,6 +52,9 @@ func TestRunAllAssemblersCommitted(t *testing.T) {
 	require.Len(t, committedRows, 3)
 	require.NotContains(t, out, "behind")
 	require.NotContains(t, out, "unreachable")
+
+	// The agreed next config block is written and carries the expected sequence.
+	require.Equal(t, uint64(1), sequenceOfWrittenBlock(t, outputPath))
 }
 
 // TestRunTimeoutSomeBehind asserts that when the timeout elapses before every
@@ -62,13 +67,17 @@ func TestRunTimeoutSomeBehind(t *testing.T) {
 	// current sequence 0, so it never reaches the expected sequence.
 	endpoints := []string{serveAssembler(t, 1), serveAssembler(t, 1), serveAssembler(t, 0)}
 	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
+	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
 
+	// With 3 parties the quorum is f+1 = 1, so the two committed assemblers still
+	// agree on the next config block; it is written despite the third being behind.
 	out := captureStdout(t, func() {
-		require.NoError(t, follow.New().Run(configPath, blockPath, 500*time.Millisecond))
+		require.NoError(t, follow.New().Run(configPath, blockPath, outputPath, 500*time.Millisecond))
 	})
 
 	require.Equal(t, 2, strings.Count(out, "committed"))
 	require.Equal(t, 1, strings.Count(out, "behind"))
+	require.Equal(t, uint64(1), sequenceOfWrittenBlock(t, outputPath))
 }
 
 // TestRunAssemblerUnreachable asserts that an assembler that never answers is
@@ -80,13 +89,54 @@ func TestRunAssemblerUnreachable(t *testing.T) {
 	// listening, so it can never be reached.
 	endpoints := []string{serveAssembler(t, 1), clienttest.FreeAddress(t)}
 	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
+	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
 
+	// With 2 parties the quorum is f+1 = 1, so the one reachable committed
+	// assembler is enough to agree on and write the next config block.
 	out := captureStdout(t, func() {
-		require.NoError(t, follow.New().Run(configPath, blockPath, 500*time.Millisecond))
+		require.NoError(t, follow.New().Run(configPath, blockPath, outputPath, 500*time.Millisecond))
 	})
 
 	require.Equal(t, 1, strings.Count(out, "committed"))
 	require.Equal(t, 1, strings.Count(out, "unreachable"))
+	require.Equal(t, uint64(1), sequenceOfWrittenBlock(t, outputPath))
+}
+
+// TestRunWritesBlockOnQuorum asserts that with 4 parties (quorum f+1 = 2), the
+// next config block is written once at least two assemblers agree on it, even
+// though a third is still behind.
+//
+//nolint:paralleltest
+func TestRunWritesBlockOnQuorum(t *testing.T) {
+	// Three of four assemblers committed sequence 1 (agreeing on the same block);
+	// the fourth is unreachable. Two agreeing assemblers already meet the quorum.
+	endpoints := []string{
+		serveAssembler(t, 1), serveAssembler(t, 1), serveAssembler(t, 1), clienttest.FreeAddress(t),
+	}
+	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
+	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
+
+	require.NoError(t, follow.New().Run(configPath, blockPath, outputPath, 500*time.Millisecond))
+	require.Equal(t, uint64(1), sequenceOfWrittenBlock(t, outputPath))
+}
+
+// TestRunNoQuorumNoBlock asserts that when fewer than a quorum of assemblers
+// agree on the next config block, follow fails and writes no output. With 4
+// parties the quorum is 2, so a single committed assembler is not enough.
+//
+//nolint:paralleltest
+func TestRunNoQuorumNoBlock(t *testing.T) {
+	// Only one assembler committed sequence 1; the other three are still behind,
+	// so the quorum of 2 is never reached.
+	endpoints := []string{
+		serveAssembler(t, 1), serveAssembler(t, 0), serveAssembler(t, 0), serveAssembler(t, 0),
+	}
+	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
+	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
+
+	err := follow.New().Run(configPath, blockPath, outputPath, 500*time.Millisecond)
+	require.ErrorContains(t, err, "no config block at last config sequence 1 was agreed by a quorum")
+	require.NoFileExists(t, outputPath)
 }
 
 // serveAssembler binds a listener and serves an assembler ledger whose last
@@ -132,15 +182,17 @@ func TestRunErrors(t *testing.T) {
 	malformedBlock := filepath.Join(t.TempDir(), "current.pb")
 	require.NoError(t, os.WriteFile(malformedBlock, []byte("not a block"), 0o600))
 
+	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
+
 	t.Run("missing config block", func(t *testing.T) {
 		t.Parallel()
-		err := follow.New().Run(configPath, filepath.Join(t.TempDir(), "absent.pb"), 30*time.Second)
+		err := follow.New().Run(configPath, filepath.Join(t.TempDir(), "absent.pb"), outputPath, 30*time.Second)
 		require.ErrorContains(t, err, "failed to read config block")
 	})
 
 	t.Run("malformed config block", func(t *testing.T) {
 		t.Parallel()
-		err := follow.New().Run(configPath, malformedBlock, 30*time.Second)
+		err := follow.New().Run(configPath, malformedBlock, outputPath, 30*time.Second)
 		require.ErrorContains(t, err, "failed to unmarshal config block")
 	})
 }
@@ -202,4 +254,15 @@ func newFollowInputs(t *testing.T, channelID string, assemblerEndpoints []string
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(configPath, content, 0o600))
 	return configPath, blockPath
+}
+
+// sequenceOfWrittenBlock reads the config block from path and returns
+// its config sequence.
+func sequenceOfWrittenBlock(t *testing.T, path string) uint64 {
+	t.Helper()
+	block, err := client.ReadConfigBlock(path)
+	require.NoError(t, err)
+	sequence, err := client.SequenceFromBlock(block)
+	require.NoError(t, err)
+	return sequence
 }

--- a/tools/fxadmin/core/ledger/ledger.go
+++ b/tools/fxadmin/core/ledger/ledger.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
+
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/client"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/seek"

--- a/tools/fxadmin/core/ledger/ledger.go
+++ b/tools/fxadmin/core/ledger/ledger.go
@@ -11,15 +11,11 @@ package ledger
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
-	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
-	"google.golang.org/protobuf/proto"
-
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/client"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/seek"
@@ -72,7 +68,7 @@ func (h *Handler) Block(configPath, currentBlockPath, reference, outputPath stri
 	if err != nil {
 		return err
 	}
-	return writeBlock(block, outputPath)
+	return client.WriteBlock(block, outputPath)
 }
 
 // Config implements `fxadmin ledger config <reference>`, fetching the last
@@ -105,24 +101,11 @@ func (h *Handler) Config(configPath, currentBlockPath, reference, outputPath str
 			return err
 		}
 	}
-	return writeBlock(configBlock, outputPath)
+	return client.WriteBlock(configBlock, outputPath)
 }
 
 // newOrdererClient loads the user configuration and the current config block, then
 // assembles an orderer client for the network the block describes.
 func (h *Handler) newOrdererClient(configPath, currentBlockPath string) (*client.Client, error) {
 	return client.LoadFromFiles(configPath, currentBlockPath, h.csp)
-}
-
-// writeBlock marshals block and writes it to path.
-func writeBlock(block *cb.Block, path string) error {
-	content, err := proto.Marshal(block)
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal block")
-	}
-	if err := os.WriteFile(path, content, 0o600); err != nil {
-		return errors.Wrapf(err, "failed to write block to %q", path)
-	}
-	fmt.Printf("block %d written to %s\n", block.GetHeader().GetNumber(), path)
-	return nil
 }

--- a/tools/fxadmin/core/ledger/ledger.go
+++ b/tools/fxadmin/core/ledger/ledger.go
@@ -69,7 +69,11 @@ func (h *Handler) Block(configPath, currentBlockPath, reference, outputPath stri
 	if err != nil {
 		return err
 	}
-	return client.WriteBlock(block, outputPath)
+	if err := client.WriteBlock(block, outputPath); err != nil {
+		return err
+	}
+	fmt.Printf("block %d written to %s\n", block.GetHeader().GetNumber(), outputPath)
+	return nil
 }
 
 // Config implements `fxadmin ledger config <reference>`, fetching the last
@@ -102,7 +106,11 @@ func (h *Handler) Config(configPath, currentBlockPath, reference, outputPath str
 			return err
 		}
 	}
-	return client.WriteBlock(configBlock, outputPath)
+	if err := client.WriteBlock(configBlock, outputPath); err != nil {
+		return err
+	}
+	fmt.Printf("block %d written to %s\n", configBlock.GetHeader().GetNumber(), outputPath)
+	return nil
 }
 
 // newOrdererClient loads the user configuration and the current config block, then

--- a/tools/fxadmin/core/tx/tx.go
+++ b/tools/fxadmin/core/tx/tx.go
@@ -252,8 +252,7 @@ func (h *Handler) Submit(inputPath, configPath, currentBlockPath string) error {
 		return errors.Wrap(err, "failed to broadcast configuration transaction")
 	}
 
-	f := (cl.NumParties() - 1) / 3
-	return reportBroadcast(statuses, 2*f+1)
+	return reportBroadcast(statuses, 2*cl.FaultThreshold()+1)
 }
 
 // readEnvelope reads and unmarshals a prepared configuration transaction


### PR DESCRIPTION
#### Type of change
New feature

#### Description
Follow command in fxadmin returns the last config block pulled from f+1 assemblers.

#### Related issues
https://github.com/hyperledger/fabric-x-orderer/issues/1067