### PR TITLE
[fxadmin] set tx id in env

### DIFF
--- a/tools/fxadmin/core/tx/tx.go
+++ b/tools/fxadmin/core/tx/tx.go
@@ -205,8 +205,7 @@ func (*Handler) Prepare(inputPath, configPath, outputPath string) error {
 		return errors.Wrapf(err, "failed to load submitting client signing identity for MSP %q", config.MSP.LocalMspID)
 	}
 
-	tx, err := protoutil.CreateSignedEnvelope(
-		cb.HeaderType_CONFIG_UPDATE, configUpdate.GetChannelId(), client, env, 0, 0)
+	tx, err := createConfigTx(configUpdate.GetChannelId(), client, env)
 	if err != nil {
 		return errors.Wrap(err, "failed to create configuration transaction")
 	}
@@ -222,6 +221,34 @@ func (*Handler) Prepare(inputPath, configPath, outputPath string) error {
 	logger.Infof("prepared configuration transaction from %s signed by %s to %s",
 		inputPath, config.MSP.LocalMspID, outputPath)
 	return nil
+}
+
+// createConfigTx wraps the endorsed ConfigUpdateEnvelope in a CONFIG_UPDATE
+// common.Envelope for channelID, signed by client. It stamps the channel header with a
+// transaction ID, so the prepared transaction carries a TxId.
+func createConfigTx(
+	channelID string, submitter msp.SigningIdentity, env *cb.ConfigUpdateEnvelope,
+) (*cb.Envelope, error) {
+	signatureHeader, err := protoutil.NewSignatureHeader(submitter)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create signature header")
+	}
+	channelHeader := protoutil.MakeChannelHeader(cb.HeaderType_CONFIG_UPDATE, 0, channelID, 0)
+	protoutil.SetTxID(channelHeader, signatureHeader)
+
+	payload := &cb.Payload{
+		Header: protoutil.MakePayloadHeader(channelHeader, signatureHeader),
+		Data:   protoutil.MarshalOrPanic(env),
+	}
+	payloadBytes, err := proto.Marshal(payload)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal configuration transaction payload")
+	}
+	signature, err := submitter.Sign(payloadBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign configuration transaction")
+	}
+	return &cb.Envelope{Payload: payloadBytes, Signature: signature}, nil
 }
 
 // Submit implements `fxadmin tx submit`. It reads the prepared configuration

--- a/tools/fxadmin/core/tx/tx_test.go
+++ b/tools/fxadmin/core/tx/tx_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/api/ordererpb"
 	"github.com/hyperledger/fabric-x-common/api/types"
 	"github.com/hyperledger/fabric-x-common/common/util"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
 	"github.com/hyperledger/fabric-x-common/tools/cryptogen"
 	"github.com/hyperledger/fabric-x-common/tools/fxadmin/core/client/test"
@@ -466,6 +467,13 @@ func TestPrepare(t *testing.T) {
 	creator, err := identity.Serialize()
 	require.NoError(t, err)
 	require.Equal(t, creator, signatureHeader.GetCreator())
+
+	// The channel header carries a transaction ID derived from the signature
+	// header's nonce and creator.
+	require.NotEmpty(t, channelHeader.GetTxId())
+	require.Equal(t,
+		protoutil.ComputeTxID(signatureHeader.GetNonce(), signatureHeader.GetCreator()),
+		channelHeader.GetTxId())
 
 	require.Equal(t, endorsed.GetConfigUpdate(), wrapped.GetConfigUpdate())
 }


### PR DESCRIPTION
#### Type of change
- New feature

#### Description
set tx id in envelope

#### Related issues
(https://github.com/hyperledger/fabric-x-orderer/issues/1067)
