### PR TITLE
Do not use stale Fabric capabilities

### DIFF
--- a/common/capabilities/channel.go
+++ b/common/capabilities/channel.go
@@ -109,8 +109,3 @@ func (cp *ChannelProvider) ConsensusTypeMigration() bool {
 func (cp *ChannelProvider) OrgSpecificOrdererEndpoints() bool {
 	return cp.v142 || cp.v143 || cp.v20 || cp.v30
 }
-
-// ConsensusTypeBFT return true if the channel supports BFT consensus.
-func (cp *ChannelProvider) ConsensusTypeBFT() bool {
-	return cp.v30
-}

--- a/common/capabilities/channel_test.go
+++ b/common/capabilities/channel_test.go
@@ -21,7 +21,6 @@ func TestChannelV10(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv1_0)
 	require.False(t, cp.ConsensusTypeMigration())
 	require.False(t, cp.OrgSpecificOrdererEndpoints())
-	require.False(t, cp.ConsensusTypeBFT())
 }
 
 func TestChannelV11(t *testing.T) {
@@ -32,7 +31,6 @@ func TestChannelV11(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv1_1)
 	require.False(t, cp.ConsensusTypeMigration())
 	require.False(t, cp.OrgSpecificOrdererEndpoints())
-	require.False(t, cp.ConsensusTypeBFT())
 }
 
 func TestChannelV13(t *testing.T) {
@@ -44,7 +42,6 @@ func TestChannelV13(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv1_3)
 	require.False(t, cp.ConsensusTypeMigration())
 	require.False(t, cp.OrgSpecificOrdererEndpoints())
-	require.False(t, cp.ConsensusTypeBFT())
 
 	cp = NewChannelProvider(map[string]*cb.Capability{
 		ChannelV1_3: {},
@@ -53,7 +50,6 @@ func TestChannelV13(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv1_3)
 	require.False(t, cp.ConsensusTypeMigration())
 	require.False(t, cp.OrgSpecificOrdererEndpoints())
-	require.False(t, cp.ConsensusTypeBFT())
 }
 
 func TestChannelV142(t *testing.T) {
@@ -65,7 +61,6 @@ func TestChannelV142(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv1_3)
 	require.True(t, cp.ConsensusTypeMigration())
 	require.True(t, cp.OrgSpecificOrdererEndpoints())
-	require.False(t, cp.ConsensusTypeBFT())
 
 	cp = NewChannelProvider(map[string]*cb.Capability{
 		ChannelV1_4_2: {},
@@ -74,7 +69,6 @@ func TestChannelV142(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv1_3)
 	require.True(t, cp.ConsensusTypeMigration())
 	require.True(t, cp.OrgSpecificOrdererEndpoints())
-	require.False(t, cp.ConsensusTypeBFT())
 }
 
 func TestChannelV143(t *testing.T) {
@@ -87,7 +81,6 @@ func TestChannelV143(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv1_4_3)
 	require.True(t, cp.ConsensusTypeMigration())
 	require.True(t, cp.OrgSpecificOrdererEndpoints())
-	require.False(t, cp.ConsensusTypeBFT())
 
 	cp = NewChannelProvider(map[string]*cb.Capability{
 		ChannelV1_4_3: {},
@@ -96,7 +89,6 @@ func TestChannelV143(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv1_4_3)
 	require.True(t, cp.ConsensusTypeMigration())
 	require.True(t, cp.OrgSpecificOrdererEndpoints())
-	require.False(t, cp.ConsensusTypeBFT())
 }
 
 func TestChannelV20(t *testing.T) {
@@ -107,7 +99,6 @@ func TestChannelV20(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv1_4_3)
 	require.True(t, cp.ConsensusTypeMigration())
 	require.True(t, cp.OrgSpecificOrdererEndpoints())
-	require.False(t, cp.ConsensusTypeBFT())
 }
 
 func TestChannelV30(t *testing.T) {
@@ -118,7 +109,6 @@ func TestChannelV30(t *testing.T) {
 	require.True(t, cp.MSPVersion() == msp.MSPv3_0)
 	require.True(t, cp.ConsensusTypeMigration())
 	require.True(t, cp.OrgSpecificOrdererEndpoints())
-	require.True(t, cp.ConsensusTypeBFT())
 }
 
 func TestChannelNotSupported(t *testing.T) {

--- a/common/channelconfig/api.go
+++ b/common/channelconfig/api.go
@@ -129,14 +129,8 @@ type ChannelCapabilities interface {
 	// and MSP principal types.
 	MSPVersion() msp.MSPVersion
 
-	// ConsensusTypeMigration return true if consensus-type migration is permitted in both orderer and peer.
-	ConsensusTypeMigration() bool
-
 	// OrgSpecificOrdererEndpoints return true if the channel config processing allows orderer orgs to specify their own endpoints
 	OrgSpecificOrdererEndpoints() bool
-
-	// ConsensusTypeBFT returns true if the channel must support BFT consensus
-	ConsensusTypeBFT() bool
 }
 
 // ApplicationCapabilities defines the capabilities for the application portion of a channel

--- a/common/channelconfig/bundle.go
+++ b/common/channelconfig/bundle.go
@@ -86,22 +86,17 @@ func (b *Bundle) ValidateNew(nb Resources) error {
 			return errors.New("current config has orderer section, but new config does not")
 		}
 
-		// Prevent consensus-type migration when channel capabilities ConsensusTypeMigration is disabled
-		if !b.channelConfig.Capabilities().ConsensusTypeMigration() {
-			if oc.ConsensusType() != noc.ConsensusType() {
-				return errors.Errorf("attempted to change consensus type from %s to %s",
-					oc.ConsensusType(), noc.ConsensusType())
-			}
+		// Prevent consensus-type migration.
+		if oc.ConsensusType() != noc.ConsensusType() {
+			return errors.Errorf("attempted to change consensus type from %s to %s",
+				oc.ConsensusType(), noc.ConsensusType())
 		}
 
-		// When we move to capability V3_0 we insist on per Org endpoints for every org
-		isOldV3 := b.ChannelConfig().Capabilities().ConsensusTypeBFT()
-		isNewV3 := nb.ChannelConfig().Capabilities().ConsensusTypeBFT()
-		if !isOldV3 && isNewV3 {
-			for _, org := range noc.Organizations() {
-				if len(org.Endpoints()) == 0 {
-					return errors.Errorf("illegal orderer config update detected: endpoints of org %s are missing", org.Name())
-				}
+		// In Fabric-X we insist on per Org endpoints for every org
+		for _, org := range noc.Organizations() {
+			if len(org.Endpoints()) == 0 {
+				return errors.Errorf(
+					"illegal orderer config update detected: endpoints of org %s are missing", org.Name())
 			}
 		}
 

--- a/common/channelconfig/bundle_test.go
+++ b/common/channelconfig/bundle_test.go
@@ -16,6 +16,20 @@ import (
 	cc "github.com/hyperledger/fabric-x-common/common/capabilities"
 )
 
+const (
+	org1Name = "org1"
+	org2Name = "org2"
+	org3Name = "org3"
+
+	org1MSPID = "org1msp"
+	org2MSPID = "org2msp"
+	org3MSPID = "org3msp"
+
+	org1Address = "org1-address"
+	org2Address = "org2-address"
+	org3Address = "org3-address"
+)
+
 func TestValidateNew(t *testing.T) {
 	t.Run("DisappearingOrdererConfig", func(t *testing.T) {
 		cb := &Bundle{
@@ -129,9 +143,9 @@ func TestValidateNew(t *testing.T) {
 						Capabilities: &cb.Capabilities{},
 					},
 					orgs: map[string]OrdererOrg{
-						"org1": &OrdererOrgConfig{OrganizationConfig: &OrganizationConfig{mspID: "org1msp"}},
-						"org2": &OrdererOrgConfig{OrganizationConfig: &OrganizationConfig{mspID: "org2msp"}},
-						"org3": &OrdererOrgConfig{OrganizationConfig: &OrganizationConfig{mspID: "org3msp"}},
+						org1Name: ordererOrgWithEndpoint(org1MSPID, org1Address),
+						org2Name: ordererOrgWithEndpoint(org2MSPID, org2Address),
+						org3Name: ordererOrgWithEndpoint(org3MSPID, org3Address),
 					},
 				},
 				protos: &ChannelProtos{
@@ -150,8 +164,8 @@ func TestValidateNew(t *testing.T) {
 						Capabilities: &cb.Capabilities{},
 					},
 					orgs: map[string]OrdererOrg{
-						"org1": &OrdererOrgConfig{OrganizationConfig: &OrganizationConfig{mspID: "org1msp"}},
-						"org3": &OrdererOrgConfig{OrganizationConfig: &OrganizationConfig{mspID: "org2msp"}},
+						org1Name: ordererOrgWithEndpoint(org1MSPID, org1Address),
+						org3Name: ordererOrgWithEndpoint(org2MSPID, org3Address),
 					},
 				},
 				protos: &ChannelProtos{
@@ -247,42 +261,33 @@ func TestValidateNew(t *testing.T) {
 }
 
 func TestValidateNewWithConsensusMigration(t *testing.T) {
-	t.Run("ConsensusTypeMigration Green Path", func(t *testing.T) {
-		for _, sysChan := range []bool{false, true} {
-			b0 := generateMigrationBundle(sysChan, "kafka", ab.ConsensusType_STATE_NORMAL)
-			b1 := generateMigrationBundle(sysChan, "kafka", ab.ConsensusType_STATE_NORMAL)
-			err := b0.ValidateNew(b1)
-			require.NoError(t, err)
+	t.Parallel()
+	t.Run("ConsensusTypeMigration Is Disabled", func(t *testing.T) {
+		t.Parallel()
+		b0 := generateMigrationBundle("kafka", ab.ConsensusType_STATE_NORMAL)
+		b1 := generateMigrationBundle("kafka", ab.ConsensusType_STATE_NORMAL)
+		err := b0.ValidateNew(b1)
+		require.NoError(t, err)
 
-			b2 := generateMigrationBundle(sysChan, "kafka", ab.ConsensusType_STATE_MAINTENANCE)
-			err = b1.ValidateNew(b2)
-			require.NoError(t, err)
+		b2 := generateMigrationBundle("kafka", ab.ConsensusType_STATE_MAINTENANCE)
+		err = b1.ValidateNew(b2)
+		require.NoError(t, err)
 
-			b3 := generateMigrationBundle(sysChan, "etcdraft", ab.ConsensusType_STATE_MAINTENANCE)
-			err = b2.ValidateNew(b3)
-			require.NoError(t, err)
-
-			b4 := generateMigrationBundle(sysChan, "etcdraft", ab.ConsensusType_STATE_NORMAL)
-			err = b3.ValidateNew(b4)
-			require.NoError(t, err)
-
-			b5 := generateMigrationBundle(sysChan, "etcdraft", ab.ConsensusType_STATE_NORMAL)
-			err = b4.ValidateNew(b5)
-			require.NoError(t, err)
-		}
+		b3 := generateMigrationBundle("etcdraft", ab.ConsensusType_STATE_MAINTENANCE)
+		err = b2.ValidateNew(b3)
+		require.EqualError(t, err, "attempted to change consensus type from kafka to etcdraft")
 	})
 
 	t.Run("ConsensusTypeMigration Abort Path", func(t *testing.T) {
-		for _, sysChan := range []bool{false, true} {
-			b1 := generateMigrationBundle(sysChan, "kafka", ab.ConsensusType_STATE_NORMAL)
-			b2 := generateMigrationBundle(sysChan, "kafka", ab.ConsensusType_STATE_MAINTENANCE)
-			err := b1.ValidateNew(b2)
-			require.NoError(t, err)
+		t.Parallel()
+		b1 := generateMigrationBundle("kafka", ab.ConsensusType_STATE_NORMAL)
+		b2 := generateMigrationBundle("kafka", ab.ConsensusType_STATE_MAINTENANCE)
+		err := b1.ValidateNew(b2)
+		require.NoError(t, err)
 
-			b3 := generateMigrationBundle(sysChan, "kafka", ab.ConsensusType_STATE_NORMAL)
-			err = b2.ValidateNew(b3)
-			require.NoError(t, err)
-		}
+		b3 := generateMigrationBundle("kafka", ab.ConsensusType_STATE_NORMAL)
+		err = b2.ValidateNew(b3)
+		require.NoError(t, err)
 	})
 }
 
@@ -410,7 +415,7 @@ func TestValidateNewWithOrgEndpoints(t *testing.T) {
 	})
 }
 
-func generateMigrationBundle(sysChan bool, cType string, cState ab.ConsensusType_State) *Bundle {
+func generateMigrationBundle(cType string, cState ab.ConsensusType_State) *Bundle {
 	b := &Bundle{
 		channelConfig: &ChannelConfig{
 			ordererConfig: &OrdererConfig{
@@ -434,10 +439,6 @@ func generateMigrationBundle(sysChan bool, cType string, cState ab.ConsensusType
 				},
 			},
 		},
-	}
-
-	if sysChan {
-		b.channelConfig.consortiumsConfig = &ConsortiumsConfig{}
 	}
 
 	return b
@@ -515,4 +516,12 @@ func TestPrevalidation(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+}
+
+// ordererOrgWithEndpoint builds an orderer org config with the given MSP ID and a single endpoint.
+func ordererOrgWithEndpoint(mspID, address string) *OrdererOrgConfig {
+	return &OrdererOrgConfig{
+		OrganizationConfig: &OrganizationConfig{mspID: mspID},
+		protos:             &OrdererOrgProtos{Endpoints: &cb.OrdererAddresses{Addresses: []string{address}}},
+	}
 }

--- a/common/channelconfig/channel.go
+++ b/common/channelconfig/channel.go
@@ -173,6 +173,9 @@ func (cc *ChannelConfig) Capabilities() ChannelCapabilities {
 
 // Validate inspects the generated configuration protos and ensures that the values are correct
 func (cc *ChannelConfig) Validate(channelCapabilities ChannelCapabilities) error {
+	// Keep the input for future introduction of capabilities
+	_ = channelCapabilities
+
 	for _, validator := range []func() error{
 		cc.validateHashingAlgorithm,
 		cc.validateBlockDataHashingStructure,
@@ -182,12 +185,8 @@ func (cc *ChannelConfig) Validate(channelCapabilities ChannelCapabilities) error
 		}
 	}
 
-	// We validate no global endpoints at V3_0 or above
-	if channelCapabilities.ConsensusTypeBFT() {
-		return cc.validateNoOrdererAddresses()
-	}
-
-	return nil
+	// We validate no global endpoints in Fabric-X, as we insist on per Org endpoints for every org.
+	return cc.validateNoOrdererAddresses()
 }
 
 func (cc *ChannelConfig) validateHashingAlgorithm() error {
@@ -210,16 +209,9 @@ func (cc *ChannelConfig) validateBlockDataHashingStructure() error {
 	return nil
 }
 
-func (cc *ChannelConfig) validateOrdererAddresses() error {
-	if len(cc.protos.OrdererAddresses.Addresses) == 0 {
-		return fmt.Errorf("Must set some OrdererAddresses")
-	}
-	return nil
-}
-
 func (cc *ChannelConfig) validateNoOrdererAddresses() error {
 	if len(cc.protos.OrdererAddresses.Addresses) > 0 {
-		return fmt.Errorf("global OrdererAddresses are not allowed with V3_0 capability, use org specific addresses only")
+		return errors.New("global OrdererAddresses are not allowed, use org specific addresses only")
 	}
 	return nil
 }

--- a/common/channelconfig/channel_test.go
+++ b/common/channelconfig/channel_test.go
@@ -69,16 +69,6 @@ func TestBlockDataHashingStructure(t *testing.T) {
 	require.Equal(t, width, cc.BlockDataHashingStructureWidth(), "Unexpected width returned")
 }
 
-func TestOrdererAddresses(t *testing.T) {
-	cc := &ChannelConfig{protos: &ChannelProtos{OrdererAddresses: &cb.OrdererAddresses{}}}
-	require.Error(t, cc.validateOrdererAddresses(), "Must supply orderer addresses")
-
-	cc = &ChannelConfig{protos: &ChannelProtos{OrdererAddresses: &cb.OrdererAddresses{Addresses: []string{"127.0.0.1:7050"}}}}
-	require.NoError(t, cc.validateOrdererAddresses(), "Invalid orderer address supplied")
-
-	require.Equal(t, "127.0.0.1:7050", cc.OrdererAddresses()[0], "Unexpected orderer address returned")
-}
-
 func TestConsortiumName(t *testing.T) {
 	cc := &ChannelConfig{protos: &ChannelProtos{Consortium: &cb.Consortium{Name: "TestConsortium"}}}
 	require.Equal(t, "TestConsortium", cc.ConsortiumName(), "Unexpected consortium name returned")

--- a/common/channelconfig/util_test.go
+++ b/common/channelconfig/util_test.go
@@ -72,7 +72,7 @@ func createCfgBlockWithSupportedCapabilities(t *testing.T) *cb.Block {
 		ModPolicy: AdminsPolicyKey,
 	}
 	topCapabilities := make(map[string]bool)
-	topCapabilities[capabilities.ChannelV1_1] = true
+	topCapabilities[capabilities.ChannelV3_0] = true
 	config.ChannelGroup.Values[CapabilitiesKey] = &cb.ConfigValue{
 		Value:     protoutil.MarshalOrPanic(CapabilitiesValue(topCapabilities).Value()),
 		ModPolicy: AdminsPolicyKey,
@@ -89,12 +89,6 @@ func createCfgBlockWithSupportedCapabilities(t *testing.T) *cb.Block {
 		}),
 		ModPolicy: AdminsPolicyKey,
 	}
-	config.ChannelGroup.Values[OrdererAddressesKey] = &cb.ConfigValue{
-		Value: protoutil.MarshalOrPanic(&cb.OrdererAddresses{
-			Addresses: []string{"orderer.example.com"},
-		}),
-		ModPolicy: AdminsPolicyKey,
-	}
 
 	// construct the config for Application group
 	config.ChannelGroup.Groups[ApplicationGroupKey] = protoutil.NewConfigGroup()
@@ -104,7 +98,7 @@ func createCfgBlockWithSupportedCapabilities(t *testing.T) *cb.Block {
 	config.ChannelGroup.Groups[ApplicationGroupKey].Policies[WritersPolicyKey] = &cb.ConfigPolicy{}
 	config.ChannelGroup.Groups[ApplicationGroupKey].Policies[AdminsPolicyKey] = &cb.ConfigPolicy{}
 	appCapabilities := make(map[string]bool)
-	appCapabilities[capabilities.ApplicationV1_1] = true
+	appCapabilities[capabilities.ApplicationV2_5] = true
 	config.ChannelGroup.Groups[ApplicationGroupKey].Values[CapabilitiesKey] = &cb.ConfigValue{
 		Value:     protoutil.MarshalOrPanic(CapabilitiesValue(appCapabilities).Value()),
 		ModPolicy: AdminsPolicyKey,
@@ -142,7 +136,7 @@ func createCfgBlockWithSupportedCapabilities(t *testing.T) *cb.Block {
 	config.ChannelGroup.Groups[OrdererGroupKey].Values[ConsensusTypeKey] = &cb.ConfigValue{
 		Value: protoutil.MarshalOrPanic(
 			&ab.ConsensusType{
-				Type: "solo",
+				Type: "arma",
 			}),
 		ModPolicy: AdminsPolicyKey,
 	}
@@ -200,12 +194,6 @@ func createCfgBlockWithUnsupportedCapabilities(t *testing.T) *cb.Block {
 	config.ChannelGroup.Values[HashingAlgorithmKey] = &cb.ConfigValue{
 		Value: protoutil.MarshalOrPanic(&cb.HashingAlgorithm{
 			Name: defaultHashingAlgorithm,
-		}),
-		ModPolicy: AdminsPolicyKey,
-	}
-	config.ChannelGroup.Values[OrdererAddressesKey] = &cb.ConfigValue{
-		Value: protoutil.MarshalOrPanic(&cb.OrdererAddresses{
-			Addresses: []string{"orderer.example.com"},
 		}),
 		ModPolicy: AdminsPolicyKey,
 	}

--- a/sampleconfig/configtx.yaml
+++ b/sampleconfig/configtx.yaml
@@ -267,7 +267,7 @@ Orderer: &OrdererDefaults
     # fault-tolerance; In BFT this number is at least 3*F+1, where F is the number of potential failures.
     # In BFT it is highly recommended that the addresses for delivery & broadcast (the OrdererEndpoints item in the
     # org definition) map 1:1 to the Orderer/ConsenterMapping (for cluster consensus). That is, every consenter should
-    # be represented by a delivery endpoint. Note that in BFT (V3) global Orderer/Addresses are no longer supported.
+    # be represented by a delivery endpoint. Note that global Orderer/Addresses are not supported.
     ConsenterMapping:
     - ID: 1
       Host: bft0.example.com


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

Do not use  stale Fabric capabilities when verifying a new bundle.
We remove the now redundant `ConsensusTypeBFT()`.

### Related issues

#178 