### PR TITLE
[fxadmin] follow compare blocks by header and data

### DIFF
--- a/tools/fxadmin/core/client/test/deliver.go
+++ b/tools/fxadmin/core/client/test/deliver.go
@@ -64,11 +64,15 @@ func (s *configDeliverStub) Deliver(stream ab.AtomicBroadcast_DeliverServer) err
 
 // ConfigLedger describes the ledger a config-deliver stub emulates: its newest
 // block number, the number of the config block that newest points at, and the
-// config sequence that config block carries.
+// config sequence that config block carries. ConfigSignatureMetadata, when set,
+// is placed in the served config block's SIGNATURES metadata slot; it lets a
+// test emulate assemblers that committed the same config block but carry
+// different orderer-signature metadata, as real assemblers do.
 type ConfigLedger struct {
-	NewestNumber   uint64
-	ConfigIndex    uint64
-	ConfigSequence uint64
+	NewestNumber            uint64
+	ConfigIndex             uint64
+	ConfigSequence          uint64
+	ConfigSignatureMetadata []byte
 }
 
 // StartConfigDeliverServer starts an in-process AtomicBroadcast server emulating
@@ -97,6 +101,9 @@ func ServeConfigDeliver(t *testing.T, lis net.Listener, ledger ConfigLedger) {
 	})
 
 	configBlock := configBlockAtSequence(ledger.ConfigIndex, ledger.ConfigSequence)
+	if ledger.ConfigSignatureMetadata != nil {
+		configBlock.Metadata.Metadata[cb.BlockMetadataIndex_SIGNATURES] = ledger.ConfigSignatureMetadata
+	}
 
 	srv := grpc.NewServer()
 	ab.RegisterAtomicBroadcastServer(srv, &configDeliverStub{newest: newest, configBlock: configBlock})

--- a/tools/fxadmin/core/follow/follow.go
+++ b/tools/fxadmin/core/follow/follow.go
@@ -58,12 +58,13 @@ func New() *Handler {
 // one assembler, so the endpoints in the current block still reach the rest;
 // assemblers that cannot be reached are reported as unreachable.
 //
-// Once at least f+1 assemblers report the identical next config block (f being
-// the number of faulty parties the network tolerates), that block is trusted —
-// f+1 matching copies guarantee at least one came from an honest assembler — and
+// Once at least f+1 assemblers report the same next config block (f being the
+// number of faulty parties the network tolerates), that block is trusted - f+1
+// matching copies guarantee at least one came from an honest assembler - and
 // written to outputPath, ready to be the --current-block of the next
-// reconfiguration. Run returns an error if no such agreement is reached before
-// the timeout.
+// reconfiguration. Blocks are matched by their header and data only, ignoring
+// the per-assembler signature metadata. Run returns an
+// error if no such agreement is reached before the timeout.
 func (h *Handler) Run(configPath, currentBlockPath, outputPath string, timeout time.Duration) error {
 	logger.Debugf("follow: config=%s current-block=%s output=%s timeout=%s",
 		configPath, currentBlockPath, outputPath, timeout)
@@ -107,9 +108,11 @@ func (h *Handler) Run(configPath, currentBlockPath, outputPath string, timeout t
 }
 
 // agreedConfigBlock returns the config block at the expected sequence that a
-// quorum of assemblers reported identically, along with the number of
-// assemblers that reported it. It returns nil when no block reaches quorum
-// copies. Blocks are compared by their full marshaled bytes.
+// quorum of assemblers reported, along with the number of assemblers that
+// reported it. It returns nil when no block reaches quorum copies.
+//
+// Blocks are compared by their header and data only, excluding the block
+// metadata (that includes the orderer signatures over the block).
 func agreedConfigBlock(results []assemblerResult, expected uint64, quorum int) (*cb.Block, int) {
 	counts := make(map[string]int)
 	blocks := make(map[string]*cb.Block)
@@ -117,12 +120,11 @@ func agreedConfigBlock(results []assemblerResult, expected uint64, quorum int) (
 		if !result.ok || result.lastConfigSequence != expected || result.configBlock == nil {
 			continue
 		}
-		marshaled, err := proto.Marshal(result.configBlock)
+		key, err := blockIdentityKey(result.configBlock)
 		if err != nil {
 			logger.Debugf("follow: skipping unmarshalable config block from %s: %v", result.endpoint, err)
 			continue
 		}
-		key := string(marshaled)
 		counts[key]++
 		blocks[key] = result.configBlock
 		if counts[key] >= quorum {
@@ -130,6 +132,18 @@ func agreedConfigBlock(results []assemblerResult, expected uint64, quorum int) (
 		}
 	}
 	return nil, 0
+}
+
+// blockIdentityKey returns a map key that identifies a block by its header and
+// data only, ignoring the (per-assembler) block metadata. It marshals a block
+// carrying just the header and data, so blocks that differ only in metadata map
+// to the same key.
+func blockIdentityKey(block *cb.Block) (string, error) {
+	marshaled, err := proto.Marshal(&cb.Block{Header: block.GetHeader(), Data: block.GetData()})
+	if err != nil {
+		return "", err
+	}
+	return string(marshaled), nil
 }
 
 // notCommitted returns how many assemblers had not committed a block at the

--- a/tools/fxadmin/core/follow/follow_internal_test.go
+++ b/tools/fxadmin/core/follow/follow_internal_test.go
@@ -99,8 +99,8 @@ func TestSummaryLine(t *testing.T) {
 }
 
 // TestAgreedConfigBlock asserts a block is returned only when the given quorum
-// of assemblers report the identical block (by full bytes) at the expected
-// sequence.
+// of assemblers report the same block — compared by header and data, ignoring
+// the per-assembler signature metadata — at the expected sequence.
 //
 //nolint:paralleltest
 func TestAgreedConfigBlock(t *testing.T) {
@@ -117,8 +117,10 @@ func TestAgreedConfigBlock(t *testing.T) {
 		require.True(t, proto.Equal(blockX, agreed))
 	})
 
-	t.Run("blocks differing only in metadata do not agree", func(t *testing.T) {
-		// Two blocks with identical headers and data but different metadata.
+	t.Run("blocks differing only in metadata agree", func(t *testing.T) {
+		// Two assemblers commit the same config block but carry different signature
+		// metadata (different order/subset of orderer signatures), as real
+		// assemblers do. They must still agree, since agreement ignores metadata.
 		signedA := protoutil.NewBlock(5, []byte("h"))
 		signedA.Metadata = &cb.BlockMetadata{Metadata: [][]byte{[]byte("sig-A")}}
 		signedB := protoutil.NewBlock(5, []byte("h"))
@@ -127,6 +129,13 @@ func TestAgreedConfigBlock(t *testing.T) {
 			"sanity: the two blocks share a header hash and differ only in metadata")
 
 		agreed, count := agreedConfigBlock([]assemblerResult{committedAt(5, signedA), committedAt(5, signedB)}, 5, 2)
+		require.NotNil(t, agreed)
+		require.Equal(t, 2, count)
+	})
+
+	t.Run("blocks differing in data do not agree", func(t *testing.T) {
+		// Same sequence but different data must not agree, even at quorum 2.
+		agreed, count := agreedConfigBlock([]assemblerResult{committedAt(5, blockX), committedAt(5, blockY)}, 5, 2)
 		require.Nil(t, agreed)
 		require.Zero(t, count)
 	})

--- a/tools/fxadmin/core/follow/follow_test.go
+++ b/tools/fxadmin/core/follow/follow_test.go
@@ -59,6 +59,26 @@ func TestRunAllAssemblersCommitted(t *testing.T) {
 	require.Equal(t, uint64(1), sequenceOfWrittenBlock(t, outputPath))
 }
 
+// TestRunAgreesDespiteDifferentSignatureMetadata asserts that assemblers which
+// committed the same next config block but carry different signature
+// metadata - as real assemblers do, still agree, and the block is written.
+// This guards the header+data (metadata-excluding) comparison.
+//
+//nolint:paralleltest
+func TestRunAgreesDespiteDifferentSignatureMetadata(t *testing.T) {
+	// Four assemblers all committed config sequence 1, but each serves the block
+	// with a distinct SIGNATURES metadata payload.
+	endpoints := []string{
+		serveAssemblerWithSigs(t, "sigs-1"), serveAssemblerWithSigs(t, "sigs-2"),
+		serveAssemblerWithSigs(t, "sigs-3"), serveAssemblerWithSigs(t, "sigs-4"),
+	}
+	configPath, blockPath := newFollowInputs(t, "test-channel", endpoints)
+	outputPath := filepath.Join(t.TempDir(), "next_config.pb")
+
+	require.NoError(t, follow.New().Run(configPath, blockPath, outputPath, 30*time.Second))
+	require.Equal(t, uint64(1), sequenceOfWrittenBlock(t, outputPath))
+}
+
 // TestRunTimeoutSomeBehind asserts that when the timeout elapses before every
 // assembler committed the next config block, follow reports the assemblers still
 // at the old sequence as behind and the rest as committed.
@@ -155,6 +175,19 @@ func serveAssembler(t *testing.T, configSequence uint64) string {
 	require.NoError(t, err)
 	clienttest.ServeConfigDeliver(t, lis, clienttest.ConfigLedger{
 		NewestNumber: 10, ConfigIndex: 5, ConfigSequence: configSequence,
+	})
+	return lis.Addr().String()
+}
+
+// serveAssemblerWithSigs is serveAssembler at config sequence 1 but sets the
+// served config block's SIGNATURES metadata to sigs.
+func serveAssemblerWithSigs(t *testing.T, sigs string) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	clienttest.ServeConfigDeliver(t, lis, clienttest.ConfigLedger{
+		NewestNumber: 10, ConfigIndex: 5, ConfigSequence: 1,
+		ConfigSignatureMetadata: []byte(sigs),
 	})
 	return lis.Addr().String()
 }


### PR DESCRIPTION
#### Type of change
- Feature update
- Test update

#### Description
follow command in fxadmin compare the header + data (without signatures)

#### Related issues
(https://github.com/hyperledger/fabric-x-orderer/issues/1067)
