### PR TITLE
[testcrypto] Let a block's owner prepare it without a clone or a rehash

### DIFF
--- a/utils/testcrypto/block.go
+++ b/utils/testcrypto/block.go
@@ -29,13 +29,22 @@ type BlockPrepareParameters struct {
 	UseIdentifierHeader bool
 	// ConsenterIDs for UseIdentifierHeader (must match ConsenterSigners length).
 	ConsenterIDs []uint32
+	// InPlace skips the deep clone and writes into the block passed in. Only for a caller that owns
+	// the block: the clone is what makes it safe to prepare a block that is reused or submitted twice.
+	InPlace bool
+	// ReuseDataHash takes the data hash from the block's existing header instead of computing it, for
+	// a caller that hashed the data off this call's critical path. Ignored when no hash is present, so
+	// forgetting to supply one gives a correct block rather than a silently corrupt one.
+	ReuseDataHash bool
 }
 
 var logger = flogging.MustGetLogger("testcrypto")
 
 // PrepareBlockHeaderAndMetadata adds a valid header and metadata to the block.
 func PrepareBlockHeaderAndMetadata(block *common.Block, p BlockPrepareParameters) *common.Block {
-	block = proto.CloneOf(block)
+	if !p.InPlace {
+		block = proto.CloneOf(block)
+	}
 	var blockNumber uint64
 	var previousHash []byte
 	if p.PrevBlock != nil {
@@ -45,9 +54,13 @@ func PrepareBlockHeaderAndMetadata(block *common.Block, p BlockPrepareParameters
 	if block.Data == nil {
 		block.Data = &common.BlockData{}
 	}
+	dataHash := block.Header.GetDataHash()
+	if !p.ReuseDataHash || len(dataHash) == 0 {
+		dataHash = protoutil.ComputeBlockDataHash(block.Data)
+	}
 	block.Header = &common.BlockHeader{
 		Number:       blockNumber,
-		DataHash:     protoutil.ComputeBlockDataHash(block.Data),
+		DataHash:     dataHash,
 		PreviousHash: previousHash,
 	}
 	meta := block.Metadata

--- a/utils/testcrypto/block_test.go
+++ b/utils/testcrypto/block_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package testcrypto
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger/fabric-x-common/protoutil"
+)
+
+// TestPrepareInPlaceMatchesClone is the check the InPlace and ReuseDataHash options rest on: they exist
+// to make preparation cheap, and they are only worth having if the block that comes out is the one that
+// would have come out anyway. Anything else would change what a committer receives while claiming to
+// change only what it costs to produce.
+func TestPrepareInPlaceMatchesClone(t *testing.T) {
+	t.Parallel()
+	prev := PrepareBlockHeaderAndMetadata(block(t, 4), BlockPrepareParameters{})
+	params := BlockPrepareParameters{PrevBlock: prev, LastConfigBlockIndex: 1}
+
+	slow := PrepareBlockHeaderAndMetadata(block(t, 4), params)
+
+	// What the fast path's caller does: hash the data itself, one stage earlier, and hand over a block
+	// it will not touch again.
+	own := block(t, 4)
+	own.Header = &common.BlockHeader{DataHash: protoutil.ComputeBlockDataHash(own.Data)}
+	fastParams := params
+	fastParams.InPlace = true
+	fastParams.ReuseDataHash = true
+	fast := PrepareBlockHeaderAndMetadata(own, fastParams)
+
+	require.Empty(t, cmpDiff(slow, fast))
+	// In place means in place: the block returned is the block passed in, not a copy of it.
+	require.Same(t, own, fast)
+}
+
+// TestReuseDataHashWithoutOneComputesIt covers the misuse: a caller that asks to reuse the hash but
+// never supplied one gets a correct block rather than one carrying an empty hash.
+func TestReuseDataHashWithoutOneComputesIt(t *testing.T) {
+	t.Parallel()
+	want := PrepareBlockHeaderAndMetadata(block(t, 3), BlockPrepareParameters{})
+	got := PrepareBlockHeaderAndMetadata(block(t, 3), BlockPrepareParameters{ReuseDataHash: true})
+	require.NotEmpty(t, got.Header.DataHash)
+	require.Empty(t, cmpDiff(want, got))
+}
+
+func block(t *testing.T, txCount int) *common.Block {
+	t.Helper()
+	data := make([][]byte, txCount)
+	for i := range data {
+		data[i] = protoutil.MarshalOrPanic(&common.Envelope{Payload: []byte{byte(i), 0x2a}})
+	}
+	return &common.Block{Data: &common.BlockData{Data: data}}
+}
+
+func cmpDiff(want, got *common.Block) string {
+	if proto.Equal(want, got) {
+		return ""
+	}
+	return "prepared blocks differ:\nwant " + want.String() + "\ngot  " + got.String()
+}


### PR DESCRIPTION
#### Type of change

- New feature
- Test update

#### Description

- `InPlace` writes the header and metadata into the block passed in, rather than into a deep clone of
  it. The clone is what makes it safe to prepare a block the caller intends to reuse or submit twice,
  so this is opt-in: for a producer that built the block for this call alone, the copy is pure waste.
- `ReuseDataHash` takes the data hash from the header the caller already filled in, so a producer can
  compute it off this call's critical path. It is ignored when the block has no header or an empty
  hash, so a caller that sets it and forgets to supply one gets a correct block rather than a silently
  corrupt one.
- Both default to today's behaviour, so no existing caller changes.
- Tested by equivalence, which is the only thing that makes the options worth having: the block
  prepared the fast way is proto-identical to the block prepared the cloning way, in place returns the
  same object it was given, and asking to reuse a hash that was never supplied still produces the
  right one.

#### Related issues

- resolves #185
